### PR TITLE
feat: Birdsong app v0.1 — Learn + Quiz modes with SRS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,98 @@
-# avilingo-v2
-Duolingo for birds again
+# Birdsong
+
+A "Duolingo for bird sounds" web app for Seattle-area birds. Learn to identify 15 common bird species by ear through structured lessons, quizzes, and spaced repetition.
+
+## Quick Start
+
+```bash
+# Download and normalize media (requires ffmpeg, first run only)
+uv run download_media.py
+
+# Start the dev server
+cd birdsong && npm install && npm run dev
+```
+
+Open http://localhost:5173 on your phone or desktop browser.
+
+## What's Built (v0.1)
+
+**Learn Mode**
+- 5 progressive lessons (3 birds each), ordered by distinctiveness
+- Swipeable bird cards with photos, mnemonics, habitat info, and audio playback
+- Intro quiz after each lesson (3-choice) with immediate feedback
+- Forward testing review questions before new cards (Lesson 2+)
+- Lesson gating: can't start next lesson until current one is complete
+
+**Quiz Mode (SRS)**
+- Spaced repetition via FSRS-5 algorithm (ts-fsrs) with custom auditory-learning parameters
+- Two exercise types: three-choice identification and same/different discrimination
+- 8-10 items per session, mix of due reviews and new introductions
+- Confusion logging for future pair-mastery tracking
+- Adaptive difficulty: same/different exercises unlock after 3+ reps per species
+
+**Progress & Credits**
+- Dashboard showing all 15 birds with SRS state, next review date, and rep count
+- Credits page with full attribution for every recording and photo
+
+**Tech Stack**
+- React 19 + TypeScript (strict), Vite, Tailwind v4
+- Zustand for state, Dexie.js (IndexedDB) for persistence
+- framer-motion for card swipe animations
+- ts-fsrs for spaced repetition scheduling
+- All audio and images self-hosted (normalized OGG Opus audio, resized JPEG photos)
+
+## Project Structure
+
+```
+birdsong/                  # React app
+  src/
+    core/                  # Pure TypeScript (no React/DOM deps)
+      types.ts             # Shared interfaces
+      manifest.ts          # Load/query bird manifest
+      lesson.ts            # Lesson sequencing logic
+      fsrs.ts              # FSRS-5 wrapper with custom params
+      quiz.ts              # Quiz session builder
+    adapters/              # Platform-specific implementations
+      audio.ts             # Web Audio API player with caching
+      storage.ts           # Dexie.js (IndexedDB) adapter
+    store/
+      appStore.ts          # Zustand global store
+    components/
+      learn/               # LearnTab, LearnSession, BirdCard, IntroQuiz
+      quiz/                # QuizTab, QuizSession, ThreeChoiceQuiz, SameDifferent, QuizResult
+      progress/            # Dashboard
+      credits/             # CreditsPage
+      shared/              # Navigation, AudioButton, AttributionInfo
+  public/content/          # Self-hosted media (gitignored)
+    audio/{species_id}/    # Normalized OGG clips
+    photos/                # Resized JPEG photos
+    manifest.json          # Manifest with local paths (checked in)
+
+download_media.py          # Downloads + normalizes all media, generates manifest
+populate_content.py        # Populates manifest with API data (already run)
+tier1_seattle_birds_populated.json  # Source data: 15 species, clips, photos, lessons
+```
+
+## Content Pipeline
+
+1. `populate_content.py` queries Wikipedia (photos) and Xeno-canto (audio) APIs to populate `tier1_seattle_birds_populated.json` (already done)
+2. `download_media.py` downloads all media, normalizes audio via ffmpeg (loudnorm, Opus 96kbps, trim to 20s), resizes photos to 800px, and generates `birdsong/public/content/manifest.json` with local paths
+3. The app fetches `/content/manifest.json` at startup and plays audio/images from same origin
+
+## Configuration
+
+The manifest (`tier1_seattle_birds_populated.json`) contains:
+- 15 species with metadata, mnemonics, habitat, confuser notes
+- 3 songs + 2 calls per species from Xeno-canto
+- Wikipedia audio (supplementary)
+- 5-lesson plan grouped by distinctiveness
+- Confuser pairs for discrimination training
+
+## To Do
+
+- **Fix swipe gestures or replace with explicit Next/Previous buttons** — the framer-motion drag-based swipe is finicky on some devices and doesn't provide clear affordances
+- **Rich media player for audio clips** — replace the simple play/stop button with a proper player that shows playback progress, supports pause, skip-ahead, replay, and scrubbing
+- Additional exercise types: clip-to-photo (no names), confuser drills
+- Offline/PWA support via service worker caching
+- Spectrogram visualization during learning
+- iOS native port (architecture supports it — core modules are pure TS)

--- a/birdsong/.gitignore
+++ b/birdsong/.gitignore
@@ -1,0 +1,28 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Downloaded media (run download_media.py to populate)
+public/content/audio/
+public/content/photos/
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/birdsong/README.md
+++ b/birdsong/README.md
@@ -1,0 +1,73 @@
+# React + TypeScript + Vite
+
+This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+
+Currently, two official plugins are available:
+
+- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
+- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+
+## React Compiler
+
+The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+
+## Expanding the ESLint configuration
+
+If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+
+```js
+export default defineConfig([
+  globalIgnores(['dist']),
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      // Other configs...
+
+      // Remove tseslint.configs.recommended and replace with this
+      tseslint.configs.recommendedTypeChecked,
+      // Alternatively, use this for stricter rules
+      tseslint.configs.strictTypeChecked,
+      // Optionally, add this for stylistic rules
+      tseslint.configs.stylisticTypeChecked,
+
+      // Other configs...
+    ],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.node.json', './tsconfig.app.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+      // other options...
+    },
+  },
+])
+```
+
+You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+
+```js
+// eslint.config.js
+import reactX from 'eslint-plugin-react-x'
+import reactDom from 'eslint-plugin-react-dom'
+
+export default defineConfig([
+  globalIgnores(['dist']),
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      // Other configs...
+      // Enable lint rules for React
+      reactX.configs['recommended-typescript'],
+      // Enable lint rules for React DOM
+      reactDom.configs.recommended,
+    ],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.node.json', './tsconfig.app.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+      // other options...
+    },
+  },
+])
+```

--- a/birdsong/eslint.config.js
+++ b/birdsong/eslint.config.js
@@ -1,0 +1,23 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+import tseslint from 'typescript-eslint'
+import { defineConfig, globalIgnores } from 'eslint/config'
+
+export default defineConfig([
+  globalIgnores(['dist']),
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.recommended,
+      reactHooks.configs.flat.recommended,
+      reactRefresh.configs.vite,
+    ],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+  },
+])

--- a/birdsong/index.html
+++ b/birdsong/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#8B6F47" />
+    <title>Birdsong</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/birdsong/package-lock.json
+++ b/birdsong/package-lock.json
@@ -1,0 +1,3435 @@
+{
+  "name": "birdsong",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "birdsong",
+      "version": "0.0.0",
+      "dependencies": {
+        "dexie": "^4.4.2",
+        "framer-motion": "^12.38.0",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "ts-fsrs": "^5.3.2",
+        "zustand": "^5.0.12"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.4",
+        "@tailwindcss/vite": "^4.2.2",
+        "@types/node": "^24.12.2",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.1",
+        "eslint": "^9.39.4",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-refresh": "^0.5.2",
+        "globals": "^17.4.0",
+        "tailwindcss": "^4.2.2",
+        "typescript": "~6.0.2",
+        "typescript-eslint": "^8.58.0",
+        "vite": "^8.0.4"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
+      "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "tailwindcss": "4.2.2"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/type-utils": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.58.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.2",
+        "@typescript-eslint/types": "^8.58.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.2",
+        "@typescript-eslint/tsconfig-utils": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
+      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dexie": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.4.2.tgz",
+      "integrity": "sha512-zMtV8q79EFE5U8FKZvt0Y/77PCU/Hr/RDxv1EDeo228L+m/HTbeN2AjoQm674rhQCX8n3ljK87lajt7UQuZfvw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.336",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
+      "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.2.tgz",
+      "integrity": "sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": "^9 || ^10"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-fsrs": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ts-fsrs/-/ts-fsrs-5.3.2.tgz",
+      "integrity": "sha512-moJJfYAeG9ynyyGCNaQPUloi0sspTMHFtgCvsx2wDchELu3O2c513/7fp+6PxsGth0ztxNjEtG8d85gX4ce0og==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.58.2",
+        "@typescript-eslint/parser": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/birdsong/package.json
+++ b/birdsong/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "birdsong",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "dexie": "^4.4.2",
+    "framer-motion": "^12.38.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "ts-fsrs": "^5.3.2",
+    "zustand": "^5.0.12"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.4",
+    "@tailwindcss/vite": "^4.2.2",
+    "@types/node": "^24.12.2",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "eslint": "^9.39.4",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-refresh": "^0.5.2",
+    "globals": "^17.4.0",
+    "tailwindcss": "^4.2.2",
+    "typescript": "~6.0.2",
+    "typescript-eslint": "^8.58.0",
+    "vite": "^8.0.4"
+  }
+}

--- a/birdsong/public/content/manifest.json
+++ b/birdsong/public/content/manifest.json
@@ -1,0 +1,1842 @@
+{
+  "version": "0.1.0",
+  "tier": 1,
+  "region": "Seattle, WA (98115 \u2014 Ravenna / University District)",
+  "target_species_count": 15,
+  "curation_date": "2026-04-13",
+  "data_sources": {
+    "audio": {
+      "primary": "Xeno-canto (xeno-canto.org)",
+      "license_filter": "CC-BY, CC-BY-SA, CC-BY-NC, CC-BY-NC-SA, CC0 \u2014 no ND variants",
+      "quality_filter": "A or B rated only",
+      "region_preference": "Washington > Oregon/BC/Idaho > rest of US",
+      "clips_per_species": "3 songs + 2 calls (target)"
+    },
+    "photos": {
+      "primary": "Wikimedia Commons (CC-BY, CC-BY-SA, CC0)",
+      "fallback": "USFWS National Digital Library (public domain)",
+      "per_species": "1 primary photo showing key field marks"
+    },
+    "frequency_data": "eBird checklists, King County WA, annual average"
+  },
+  "species": [
+    {
+      "id": "amro",
+      "common_name": "American Robin",
+      "scientific_name": "Turdus migratorius",
+      "family": "Turdidae",
+      "ebird_frequency_pct": 45,
+      "habitat": [
+        "backyard",
+        "parkland",
+        "forest edge"
+      ],
+      "seasonality": "year-round",
+      "mnemonic": "Cheerily, cheer-up, cheerily \u2014 a caroling whistle at dawn and dusk",
+      "sound_types": {
+        "song": "Rich caroling whistle, phrases of 2-3 syllables with rising and falling pitch",
+        "call": "Sharp tut-tut-tut alarm; also a thin, high seep in flight"
+      },
+      "confuser_species": [
+        "Varied Thrush",
+        "Black-headed Grosbeak"
+      ],
+      "confuser_notes": "Varied Thrush has a single eerie buzzy note on one pitch, not a caroling phrase",
+      "xc_api_query": "https://xeno-canto.org/api/2/recordings?query=Turdus+migratorius+cnt:%22United+States%22+q:A",
+      "wikimedia_search": "https://commons.wikimedia.org/w/index.php?search=American+Robin+Turdus+migratorius&type=image",
+      "audio_clips": {
+        "songs": [
+          {
+            "xc_id": "550087",
+            "xc_url": "https://xeno-canto.org/550087",
+            "audio_url": "/content/audio/amro/550087.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:08",
+            "recordist": "Bruce Lagerquist",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Thornton Creek Ravine, Seattle, King County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "666135",
+            "xc_url": "https://xeno-canto.org/666135",
+            "audio_url": "/content/audio/amro/666135.ogg",
+            "type": "dawn song",
+            "quality": "A",
+            "length": "0:45",
+            "recordist": "Steve Hampton",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Port Townsend, Jefferson County, Washington",
+            "country": "United States",
+            "score": 10.5
+          },
+          {
+            "xc_id": "319833",
+            "xc_url": "https://xeno-canto.org/319833",
+            "audio_url": "/content/audio/amro/319833.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:39",
+            "recordist": "John Leszczynski",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Washington, District of Columbia, District of Columbia",
+            "country": "United States",
+            "score": 10.5
+          }
+        ],
+        "calls": [
+          {
+            "xc_id": "550893",
+            "xc_url": "https://xeno-canto.org/550893",
+            "audio_url": "/content/audio/amro/550893.ogg",
+            "type": "call",
+            "quality": "A",
+            "length": "0:10",
+            "recordist": "Bruce Lagerquist",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Thornton Creek Ravine, Seattle, King County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "550889",
+            "xc_url": "https://xeno-canto.org/550889",
+            "audio_url": "/content/audio/amro/550889.ogg",
+            "type": "alarm call",
+            "quality": "A",
+            "length": "0:14",
+            "recordist": "Bruce Lagerquist",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Thornton Creek Ravine, Seattle, King County, Washington",
+            "country": "United States",
+            "score": 11.5
+          }
+        ]
+      },
+      "photo": {
+        "url": "/content/photos/amro.jpg",
+        "width": 3444,
+        "height": 2584,
+        "filename": "American_robin_(71307).jpg",
+        "source": "wikipedia_infobox",
+        "license": "CC-BY-SA (Wikipedia)",
+        "wikipedia_page": "https://en.wikipedia.org/wiki/American%20robin"
+      },
+      "wikipedia_audio": [
+        {
+          "url": "/content/audio/amro/wp_0.ogg",
+          "filename": "File:American Robin.ogg",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3AAmerican%20Robin.ogg"
+        },
+        {
+          "url": "/content/audio/amro/wp_1.ogg",
+          "filename": "File:Turdus-migratorius-003.ogg",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3ATurdus-migratorius-003.ogg"
+        }
+      ]
+    },
+    {
+      "id": "amcr",
+      "common_name": "American Crow",
+      "scientific_name": "Corvus brachyrhynchos",
+      "family": "Corvidae",
+      "ebird_frequency_pct": 42,
+      "habitat": [
+        "urban",
+        "backyard",
+        "parkland"
+      ],
+      "seasonality": "year-round",
+      "mnemonic": "Loud, harsh caw-caw-caw \u2014 evenly spaced, no rattle",
+      "sound_types": {
+        "song": "N/A \u2014 crows don't have a true song",
+        "call": "Harsh caw-caw-caw, usually 3-8 caws in a series"
+      },
+      "confuser_species": [
+        "Common Raven"
+      ],
+      "confuser_notes": "Raven is deeper, hoarser, and gives a croaking pruk-pruk rather than a clean caw",
+      "xc_api_query": "https://xeno-canto.org/api/2/recordings?query=Corvus+brachyrhynchos+cnt:%22United+States%22+q:A",
+      "wikimedia_search": "https://commons.wikimedia.org/w/index.php?search=American+Crow+Corvus+brachyrhynchos&type=image",
+      "audio_clips": {
+        "songs": [
+          {
+            "xc_id": "481136",
+            "xc_url": "https://xeno-canto.org/481136",
+            "audio_url": "/content/audio/amcr/481136.ogg",
+            "type": "call, song",
+            "quality": "A",
+            "length": "0:26",
+            "recordist": "Meena Haribal",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Pinnacles National Park, San Benito County, California",
+            "country": "United States",
+            "score": 8.0
+          },
+          {
+            "xc_id": "420594",
+            "xc_url": "https://xeno-canto.org/420594",
+            "audio_url": "/content/audio/amcr/420594.ogg",
+            "type": "song",
+            "quality": "B",
+            "length": "0:39",
+            "recordist": "Meena Haribal",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Brinnon, Jefferson County, Washington",
+            "country": "United States",
+            "score": 8
+          },
+          {
+            "xc_id": "114556",
+            "xc_url": "https://xeno-canto.org/114556",
+            "audio_url": "/content/audio/amcr/114556.ogg",
+            "type": "song, whisper song",
+            "quality": "A",
+            "length": "0:26",
+            "recordist": "Nathan Pieplow",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/3.0/",
+            "location": "Moraine Park, Rocky Mountain National Park, Larimer, Colorado",
+            "country": "United States",
+            "score": 7.5
+          }
+        ],
+        "calls": [
+          {
+            "xc_id": "550085",
+            "xc_url": "https://xeno-canto.org/550085",
+            "audio_url": "/content/audio/amcr/550085.ogg",
+            "type": "call",
+            "quality": "A",
+            "length": "0:17",
+            "recordist": "Bruce Lagerquist",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Thornton Creek Ravine, Seattle, King County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "289011",
+            "xc_url": "https://xeno-canto.org/289011",
+            "audio_url": "/content/audio/amcr/289011.ogg",
+            "type": "call",
+            "quality": "A",
+            "length": "0:15",
+            "recordist": "David Vander Pluym",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Marymoor Park, King County, Washington",
+            "country": "United States",
+            "score": 11.5
+          }
+        ]
+      },
+      "photo": {
+        "url": "/content/photos/amcr.jpg",
+        "width": 1536,
+        "height": 1536,
+        "filename": "Corvus-brachyrhynchos-001.jpg",
+        "source": "wikipedia_infobox",
+        "license": "CC-BY-SA (Wikipedia)",
+        "wikipedia_page": "https://en.wikipedia.org/wiki/American%20crow"
+      },
+      "wikipedia_audio": [
+        {
+          "url": "/content/audio/amcr/wp_0.ogg",
+          "filename": "File:American crow in spring.ogg",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3AAmerican%20crow%20in%20spring.ogg"
+        },
+        {
+          "url": "/content/audio/amcr/wp_1.ogg",
+          "filename": "File:Corvus brachyrhynchos - American Crow - XC115429.ogg",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3ACorvus%20brachyrhynchos%20-%20American%20Crow%20-%20XC115429.ogg"
+        }
+      ]
+    },
+    {
+      "id": "sosp",
+      "common_name": "Song Sparrow",
+      "scientific_name": "Melospiza melodia",
+      "family": "Passerellidae",
+      "ebird_frequency_pct": 38,
+      "habitat": [
+        "backyard",
+        "wetland edge",
+        "brush"
+      ],
+      "seasonality": "year-round",
+      "mnemonic": "Starts with 3 clear notes (sweet-sweet-sweet), then a buzzy trill \u2014 Beethoven's 5th opening",
+      "sound_types": {
+        "song": "3 clear introductory notes followed by varied buzzy trills",
+        "call": "Sharp chimp call note"
+      },
+      "confuser_species": [
+        "Fox Sparrow",
+        "Lincoln's Sparrow",
+        "Savannah Sparrow"
+      ],
+      "confuser_notes": "Fox Sparrow is richer and more musical; Lincoln's is buzzier throughout; Savannah is more insect-like",
+      "xc_api_query": "https://xeno-canto.org/api/2/recordings?query=Melospiza+melodia+cnt:%22United+States%22+q:A",
+      "wikimedia_search": "https://commons.wikimedia.org/w/index.php?search=Song+Sparrow+Melospiza+melodia&type=image",
+      "audio_clips": {
+        "songs": [
+          {
+            "xc_id": "663787",
+            "xc_url": "https://xeno-canto.org/663787",
+            "audio_url": "/content/audio/sosp/663787.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:26",
+            "recordist": "Whitney Neufeld-Kaiser",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Yost Park (near  Edmonds), Snohomish County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "473434",
+            "xc_url": "https://xeno-canto.org/473434",
+            "audio_url": "/content/audio/sosp/473434.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:21",
+            "recordist": "bowtyler",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Olympia, Thurston County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "473424",
+            "xc_url": "https://xeno-canto.org/473424",
+            "audio_url": "/content/audio/sosp/473424.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:29",
+            "recordist": "bowtyler",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Olympia, Thurston County, Washington",
+            "country": "United States",
+            "score": 11.5
+          }
+        ],
+        "calls": [
+          {
+            "xc_id": "972394",
+            "xc_url": "https://xeno-canto.org/972394",
+            "audio_url": "/content/audio/sosp/972394.ogg",
+            "type": "call",
+            "quality": "A",
+            "length": "0:17",
+            "recordist": "Whitney Neufeld-Kaiser",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Seattle, King County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "644849",
+            "xc_url": "https://xeno-canto.org/644849",
+            "audio_url": "/content/audio/sosp/644849.ogg",
+            "type": "alarm call",
+            "quality": "A",
+            "length": "0:07",
+            "recordist": "Larry Sirvio",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Denmark Township (near  Hastings), Washington County, Minnesota",
+            "country": "United States",
+            "score": 11.5
+          }
+        ]
+      },
+      "photo": {
+        "url": "/content/photos/sosp.jpg",
+        "width": 3257,
+        "height": 2284,
+        "filename": "Song_sparrow_in_Prospect_Park_(93031).jpg",
+        "source": "wikipedia_infobox",
+        "license": "CC-BY-SA (Wikipedia)",
+        "wikipedia_page": "https://en.wikipedia.org/wiki/Song%20sparrow"
+      },
+      "wikipedia_audio": [
+        {
+          "url": "/content/audio/sosp/wp_0.ogg",
+          "filename": "File:Melospiza-melodia-001.ogg",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3AMelospiza-melodia-001.ogg"
+        }
+      ]
+    },
+    {
+      "id": "deju",
+      "common_name": "Dark-eyed Junco",
+      "scientific_name": "Junco hyemalis",
+      "family": "Passerellidae",
+      "ebird_frequency_pct": 35,
+      "habitat": [
+        "backyard",
+        "forest floor",
+        "brush"
+      ],
+      "seasonality": "year-round (Oregon subspecies in Seattle)",
+      "mnemonic": "Simple even trill on one pitch \u2014 like a ringing telephone",
+      "sound_types": {
+        "song": "Even-pitched musical trill, 1-2 seconds long",
+        "call": "Sharp ticking tsik notes, often in rapid series when flushed"
+      },
+      "confuser_species": [
+        "Chipping Sparrow",
+        "Pine Siskin"
+      ],
+      "confuser_notes": "Chipping Sparrow trill is drier and faster; Pine Siskin trill rises at the end",
+      "xc_api_query": "https://xeno-canto.org/api/2/recordings?query=Junco+hyemalis+cnt:%22United+States%22+q:A",
+      "wikimedia_search": "https://commons.wikimedia.org/w/index.php?search=Dark-eyed+Junco+Junco+hyemalis&type=image",
+      "audio_clips": {
+        "songs": [
+          {
+            "xc_id": "766386",
+            "xc_url": "https://xeno-canto.org/766386",
+            "audio_url": "/content/audio/deju/766386.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:22",
+            "recordist": "Bruce Lagerquist",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Dawson Canyon, Kittitas County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "178940",
+            "xc_url": "https://xeno-canto.org/178940",
+            "audio_url": "/content/audio/deju/178940.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:29",
+            "recordist": "Eric Cannizzaro",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Olympic National Forest (near  Montesano), Mason County, Washington",
+            "country": "United States",
+            "score": 11
+          },
+          {
+            "xc_id": "1083920",
+            "xc_url": "https://xeno-canto.org/1083920",
+            "audio_url": "/content/audio/deju/1083920.ogg",
+            "type": "call, song",
+            "quality": "A",
+            "length": "0:48",
+            "recordist": "Greg Irving",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Dungeness Recreation Area, Clallam County, Washington",
+            "country": "United States",
+            "score": 10
+          }
+        ],
+        "calls": [
+          {
+            "xc_id": "1024572",
+            "xc_url": "https://xeno-canto.org/1024572",
+            "audio_url": "/content/audio/deju/1024572.ogg",
+            "type": "call",
+            "quality": "A",
+            "length": "0:19",
+            "recordist": "Greg Irving",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Deer Park Campground, Olympic National Park, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "477131",
+            "xc_url": "https://xeno-canto.org/477131",
+            "audio_url": "/content/audio/deju/477131.ogg",
+            "type": "call",
+            "quality": "A",
+            "length": "0:14",
+            "recordist": "Bates Estabrooks",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Bremerton, Kitsap County, Washington",
+            "country": "United States",
+            "score": 11.5
+          }
+        ]
+      },
+      "photo": {
+        "url": "/content/photos/deju.jpg",
+        "width": 2536,
+        "height": 1692,
+        "filename": "Junco_hyemalis_hyemalis_CT1_(cropped).jpg",
+        "source": "wikipedia_infobox",
+        "license": "CC-BY-SA (Wikipedia)",
+        "wikipedia_page": "https://en.wikipedia.org/wiki/Dark-eyed%20junco"
+      }
+    },
+    {
+      "id": "bcch",
+      "common_name": "Black-capped Chickadee",
+      "scientific_name": "Poecile atricapillus",
+      "family": "Paridae",
+      "ebird_frequency_pct": 33,
+      "habitat": [
+        "backyard",
+        "deciduous forest",
+        "parkland"
+      ],
+      "seasonality": "year-round",
+      "mnemonic": "Song: clear whistled fee-bee (2 notes, second lower). Call: chick-a-dee-dee-dee",
+      "sound_types": {
+        "song": "Clear 2-note whistle: fee-bee, second note lower",
+        "call": "Chick-a-dee-dee-dee \u2014 more dees = higher alarm level"
+      },
+      "confuser_species": [
+        "Chestnut-backed Chickadee"
+      ],
+      "confuser_notes": "Chestnut-backed is faster, higher-pitched, and lacks the clear fee-bee song",
+      "xc_api_query": "https://xeno-canto.org/api/2/recordings?query=Poecile+atricapillus+cnt:%22United+States%22+q:A",
+      "wikimedia_search": "https://commons.wikimedia.org/w/index.php?search=Black-capped+Chickadee+Poecile+atricapillus&type=image",
+      "audio_clips": {
+        "songs": [
+          {
+            "xc_id": "549584",
+            "xc_url": "https://xeno-canto.org/549584",
+            "audio_url": "/content/audio/bcch/549584.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:43",
+            "recordist": "Bruce Lagerquist",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Thornton Creek Ravine, Seattle, King County, Washington",
+            "country": "United States",
+            "score": 10.5
+          },
+          {
+            "xc_id": "624457",
+            "xc_url": "https://xeno-canto.org/624457",
+            "audio_url": "/content/audio/bcch/624457.ogg",
+            "type": "aberrant, song",
+            "quality": "A",
+            "length": "0:25",
+            "recordist": "Thomas Magarian",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "2310 North Wygant Street, North Portland, Multnomah County, Oregon",
+            "country": "United States",
+            "score": 9.5
+          },
+          {
+            "xc_id": "624456",
+            "xc_url": "https://xeno-canto.org/624456",
+            "audio_url": "/content/audio/bcch/624456.ogg",
+            "type": "aberrant, song",
+            "quality": "A",
+            "length": "0:20",
+            "recordist": "Thomas Magarian",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "2310 North Wygant Street, North Portland, Multnomah County, Oregon",
+            "country": "United States",
+            "score": 9.5
+          }
+        ],
+        "calls": [
+          {
+            "xc_id": "582380",
+            "xc_url": "https://xeno-canto.org/582380",
+            "audio_url": "/content/audio/bcch/582380.ogg",
+            "type": "call",
+            "quality": "A",
+            "length": "0:18",
+            "recordist": "James Link",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Quilcene, Jefferson County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "473414",
+            "xc_url": "https://xeno-canto.org/473414",
+            "audio_url": "/content/audio/bcch/473414.ogg",
+            "type": "call",
+            "quality": "A",
+            "length": "0:46",
+            "recordist": "bowtyler",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Olympia, Thurston County, Washington",
+            "country": "United States",
+            "score": 10.5
+          }
+        ]
+      },
+      "photo": {
+        "url": "/content/photos/bcch.jpg",
+        "width": 1024,
+        "height": 1024,
+        "filename": "Poecile-atricapilla-001.jpg",
+        "source": "wikipedia_infobox",
+        "license": "CC-BY-SA (Wikipedia)",
+        "wikipedia_page": "https://en.wikipedia.org/wiki/Black-capped%20chickadee"
+      },
+      "wikipedia_audio": [
+        {
+          "url": "/content/audio/bcch/wp_0.ogg",
+          "filename": "File:Poecile-atricapilla-004.ogg",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3APoecile-atricapilla-004.ogg"
+        },
+        {
+          "url": "/content/audio/bcch/wp_1.ogg",
+          "filename": "File:Poecile atricapillus - Black-capped Chickadee - XC70185.ogg",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3APoecile%20atricapillus%20-%20Black-capped%20Chickadee%20-%20XC70185.ogg"
+        }
+      ]
+    },
+    {
+      "id": "spto",
+      "common_name": "Spotted Towhee",
+      "scientific_name": "Pipilo maculatus",
+      "family": "Passerellidae",
+      "ebird_frequency_pct": 30,
+      "habitat": [
+        "brush",
+        "backyard thickets",
+        "forest edge"
+      ],
+      "seasonality": "year-round",
+      "mnemonic": "Drink-your-teeeee \u2014 two short intro notes then a buzzy trill",
+      "sound_types": {
+        "song": "2 short clear notes followed by a fast trill",
+        "call": "Cat-like mewing call; also a sharp chewink from underbrush"
+      },
+      "confuser_species": [
+        "Dark-eyed Junco"
+      ],
+      "confuser_notes": "Junco trill is more even and simpler; Towhee has the distinctive 2-note intro",
+      "xc_api_query": "https://xeno-canto.org/api/2/recordings?query=Pipilo+maculatus+cnt:%22United+States%22+q:A",
+      "wikimedia_search": "https://commons.wikimedia.org/w/index.php?search=Spotted+Towhee+Pipilo+maculatus&type=image",
+      "audio_clips": {
+        "songs": [
+          {
+            "xc_id": "948903",
+            "xc_url": "https://xeno-canto.org/948903",
+            "audio_url": "/content/audio/spto/948903.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:19",
+            "recordist": "Whitney Neufeld-Kaiser",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Twisp, Okanogan County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "647613",
+            "xc_url": "https://xeno-canto.org/647613",
+            "audio_url": "/content/audio/spto/647613.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:26",
+            "recordist": "Whitney Neufeld-Kaiser",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Stanwood, Snohomish County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "547332",
+            "xc_url": "https://xeno-canto.org/547332",
+            "audio_url": "/content/audio/spto/547332.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:20",
+            "recordist": "Bruce Lagerquist",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Maple Leaf, Seattle, King County, Washington",
+            "country": "United States",
+            "score": 11.5
+          }
+        ],
+        "calls": [
+          {
+            "xc_id": "582159",
+            "xc_url": "https://xeno-canto.org/582159",
+            "audio_url": "/content/audio/spto/582159.ogg",
+            "type": "call",
+            "quality": "A",
+            "length": "0:29",
+            "recordist": "James Link",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Port Hadlock-Irondale, Jefferson County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "473453",
+            "xc_url": "https://xeno-canto.org/473453",
+            "audio_url": "/content/audio/spto/473453.ogg",
+            "type": "call",
+            "quality": "A",
+            "length": "0:29",
+            "recordist": "bowtyler",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Mission Creek Nature Park (near  Olympia), Thurston County, Washington",
+            "country": "United States",
+            "score": 11.5
+          }
+        ]
+      },
+      "photo": {
+        "url": "/content/photos/spto.jpg",
+        "width": 2273,
+        "height": 1818,
+        "filename": "Spotted_Towhee_(32684403303).jpg",
+        "source": "wikipedia_infobox",
+        "license": "CC-BY-SA (Wikipedia)",
+        "wikipedia_page": "https://en.wikipedia.org/wiki/Spotted%20towhee"
+      },
+      "wikipedia_audio": [
+        {
+          "url": "/content/audio/spto/wp_0.ogg",
+          "filename": "File:Pipilo maculatus - Spotted Towhee - XC104528.ogg",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3APipilo%20maculatus%20-%20Spotted%20Towhee%20-%20XC104528.ogg"
+        }
+      ]
+    },
+    {
+      "id": "hofi",
+      "common_name": "House Finch",
+      "scientific_name": "Haemorhous mexicanus",
+      "family": "Fringillidae",
+      "ebird_frequency_pct": 29,
+      "habitat": [
+        "urban",
+        "backyard",
+        "buildings"
+      ],
+      "seasonality": "year-round",
+      "mnemonic": "Long warbling jumble ending with a harsh buzzy zhreee \u2014 sounds happy but messy",
+      "sound_types": {
+        "song": "Rapid warbling series, often ending with a buzzy downslurred note",
+        "call": "Sharp chirp in flight"
+      },
+      "confuser_species": [
+        "Purple Finch",
+        "Cassin's Finch"
+      ],
+      "confuser_notes": "Purple Finch is richer and more musical without the harsh ending; Cassin's is higher and clearer",
+      "xc_api_query": "https://xeno-canto.org/api/2/recordings?query=Haemorhous+mexicanus+cnt:%22United+States%22+q:A",
+      "wikimedia_search": "https://commons.wikimedia.org/w/index.php?search=House+Finch+Haemorhous+mexicanus&type=image",
+      "audio_clips": {
+        "songs": [
+          {
+            "xc_id": "638608",
+            "xc_url": "https://xeno-canto.org/638608",
+            "audio_url": "/content/audio/hofi/638608.ogg",
+            "type": "call, song",
+            "quality": "A",
+            "length": "0:37",
+            "recordist": "Bruce Lagerquist",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Cassimer Bar, Okanogan County, Washington",
+            "country": "United States",
+            "score": 10.5
+          },
+          {
+            "xc_id": "468779",
+            "xc_url": "https://xeno-canto.org/468779",
+            "audio_url": "/content/audio/hofi/468779.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:45",
+            "recordist": "Bruce Lagerquist",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Deadman Creek, Garfield County, Washington",
+            "country": "United States",
+            "score": 10.5
+          },
+          {
+            "xc_id": "584861",
+            "xc_url": "https://xeno-canto.org/584861",
+            "audio_url": "/content/audio/hofi/584861.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:29",
+            "recordist": "Thomas Magarian",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Columbia Childrens Arboretum, Portland, Multnomah County, Oregon",
+            "country": "United States",
+            "score": 9
+          }
+        ],
+        "calls": [
+          {
+            "xc_id": "638608",
+            "xc_url": "https://xeno-canto.org/638608",
+            "audio_url": "/content/audio/hofi/638608.ogg",
+            "type": "call, song",
+            "quality": "A",
+            "length": "0:37",
+            "recordist": "Bruce Lagerquist",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Cassimer Bar, Okanogan County, Washington",
+            "country": "United States",
+            "score": 10.5
+          },
+          {
+            "xc_id": "1056012",
+            "xc_url": "https://xeno-canto.org/1056012",
+            "audio_url": "/content/audio/hofi/1056012.ogg",
+            "type": "call",
+            "quality": "B",
+            "length": "0:11",
+            "recordist": "Denis Dujardin",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Tualatin River NWR, Washington County, Oregon",
+            "country": "United States",
+            "score": 9
+          }
+        ]
+      },
+      "photo": {
+        "url": "/content/photos/hofi.jpg",
+        "width": 3975,
+        "height": 3122,
+        "filename": "House_finch_(33688)2.jpg",
+        "source": "wikipedia_infobox",
+        "license": "CC-BY-SA (Wikipedia)",
+        "wikipedia_page": "https://en.wikipedia.org/wiki/House%20finch"
+      },
+      "wikipedia_audio": [
+        {
+          "url": "/content/audio/hofi/wp_0.ogg",
+          "filename": "File:Carpodacus mexicanus vocalizations - pone.0027052.s006.oga",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3ACarpodacus%20mexicanus%20vocalizations%20-%20pone.0027052.s006.oga"
+        }
+      ]
+    },
+    {
+      "id": "nofl",
+      "common_name": "Northern Flicker",
+      "scientific_name": "Colaptes auratus",
+      "family": "Picidae",
+      "ebird_frequency_pct": 28,
+      "habitat": [
+        "backyard",
+        "parkland",
+        "open woodland"
+      ],
+      "seasonality": "year-round (Red-shafted subspecies)",
+      "mnemonic": "Loud wick-wick-wick-wick (like rapid laughter) or a single loud kyeer",
+      "sound_types": {
+        "song": "Loud, rapid wick-wick-wick-wick lasting several seconds",
+        "call": "Single loud kyeer or klee-yer; also drums on metal for resonance"
+      },
+      "confuser_species": [
+        "Pileated Woodpecker"
+      ],
+      "confuser_notes": "Pileated is louder, slower, and has a wilder irregular rhythm; Flicker is evenly spaced",
+      "xc_api_query": "https://xeno-canto.org/api/2/recordings?query=Colaptes+auratus+cnt:%22United+States%22+q:A",
+      "wikimedia_search": "https://commons.wikimedia.org/w/index.php?search=Northern+Flicker+Colaptes+auratus&type=image",
+      "audio_clips": {
+        "songs": [
+          {
+            "xc_id": "613548",
+            "xc_url": "https://xeno-canto.org/613548",
+            "audio_url": "/content/audio/nofl/613548.ogg",
+            "type": "begging call, song",
+            "quality": "A",
+            "length": "0:30",
+            "recordist": "Peter Ward and Ken Hall",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Icicle River near Leavenworth, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "604689",
+            "xc_url": "https://xeno-canto.org/604689",
+            "audio_url": "/content/audio/nofl/604689.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:26",
+            "recordist": "Bruce Lagerquist",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Maple Leaf, Seattle, King County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "1007124",
+            "xc_url": "https://xeno-canto.org/1007124",
+            "audio_url": "/content/audio/nofl/1007124.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:26",
+            "recordist": "Ed Pandolfino",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Dean's Crick, Sierra County, California",
+            "country": "United States",
+            "score": 7.5
+          }
+        ],
+        "calls": [
+          {
+            "xc_id": "613548",
+            "xc_url": "https://xeno-canto.org/613548",
+            "audio_url": "/content/audio/nofl/613548.ogg",
+            "type": "begging call, song",
+            "quality": "A",
+            "length": "0:30",
+            "recordist": "Peter Ward and Ken Hall",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Icicle River near Leavenworth, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "550950",
+            "xc_url": "https://xeno-canto.org/550950",
+            "audio_url": "/content/audio/nofl/550950.ogg",
+            "type": "call",
+            "quality": "A",
+            "length": "0:06",
+            "recordist": "Bruce Lagerquist",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Thornton Creek Ravine, Seattle, King County, Washington",
+            "country": "United States",
+            "score": 11.5
+          }
+        ]
+      },
+      "photo": {
+        "url": "/content/photos/nofl.jpg",
+        "width": 2441,
+        "height": 2442,
+        "filename": "Northern_yellow-shafted_flicker_male_(33737)_(cropped).jpg",
+        "source": "wikipedia_infobox",
+        "license": "CC-BY-SA (Wikipedia)",
+        "wikipedia_page": "https://en.wikipedia.org/wiki/Northern%20flicker"
+      },
+      "wikipedia_audio": [
+        {
+          "url": "/content/audio/nofl/wp_0.ogg",
+          "filename": "File:Colaptes auratus.ogg",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3AColaptes%20auratus.ogg"
+        },
+        {
+          "url": "/content/audio/nofl/wp_1.ogg",
+          "filename": "File:Northern Flicker Yosemite National Park.ogg",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3ANorthern%20Flicker%20Yosemite%20National%20Park.ogg"
+        }
+      ]
+    },
+    {
+      "id": "stja",
+      "common_name": "Steller's Jay",
+      "scientific_name": "Cyanocitta stelleri",
+      "family": "Corvidae",
+      "ebird_frequency_pct": 27,
+      "habitat": [
+        "coniferous forest",
+        "backyard",
+        "parkland"
+      ],
+      "seasonality": "year-round",
+      "mnemonic": "Harsh shack-shack-shack \u2014 also a great mimic (imitates Red-tailed Hawk screams)",
+      "sound_types": {
+        "song": "N/A \u2014 jays don't have a traditional song",
+        "call": "Harsh shack-shack-shack alarm; also a variety of squeaky, rattling calls"
+      },
+      "confuser_species": [
+        "Blue Jay"
+      ],
+      "confuser_notes": "Blue Jay (rare in Seattle) has a clearer jay-jay call; Steller's is harsher and more grating",
+      "xc_api_query": "https://xeno-canto.org/api/2/recordings?query=Cyanocitta+stelleri+cnt:%22United+States%22+q:A",
+      "wikimedia_search": "https://commons.wikimedia.org/w/index.php?search=Steller%27s+Jay+Cyanocitta+stelleri&type=image",
+      "audio_clips": {
+        "songs": [
+          {
+            "xc_id": "456270",
+            "xc_url": "https://xeno-canto.org/456270",
+            "audio_url": "/content/audio/stja/456270.ogg",
+            "type": "call, song",
+            "quality": "A",
+            "length": "0:56",
+            "recordist": "Alan Knue",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Ballinger Park, Mountlake Terrace, Snohomish County, Washington",
+            "country": "United States",
+            "score": 10.5
+          },
+          {
+            "xc_id": "456269",
+            "xc_url": "https://xeno-canto.org/456269",
+            "audio_url": "/content/audio/stja/456269.ogg",
+            "type": "call, song",
+            "quality": "A",
+            "length": "0:36",
+            "recordist": "Alan Knue",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Ballinger Park, Mountlake Terrace, Snohomish County, Washington",
+            "country": "United States",
+            "score": 10.5
+          },
+          {
+            "xc_id": "456271",
+            "xc_url": "https://xeno-canto.org/456271",
+            "audio_url": "/content/audio/stja/456271.ogg",
+            "type": "call, song",
+            "quality": "A",
+            "length": "1:12",
+            "recordist": "Alan Knue",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Ballinger Park, Mountlake Terrace, Snohomish County, Washington",
+            "country": "United States",
+            "score": 9.5
+          }
+        ],
+        "calls": [
+          {
+            "xc_id": "703911",
+            "xc_url": "https://xeno-canto.org/703911",
+            "audio_url": "/content/audio/stja/703911.ogg",
+            "type": "call",
+            "quality": "A",
+            "length": "0:11",
+            "recordist": "Steve Hampton",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Port Townsend, Jefferson County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "670954",
+            "xc_url": "https://xeno-canto.org/670954",
+            "audio_url": "/content/audio/stja/670954.ogg",
+            "type": "call",
+            "quality": "A",
+            "length": "0:14",
+            "recordist": "Phoebe Barnes",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Quarry Ridge Farm (private), Clark County, Washington",
+            "country": "United States",
+            "score": 11.5
+          }
+        ]
+      },
+      "photo": {
+        "url": "/content/photos/stja.jpg",
+        "width": 1226,
+        "height": 1854,
+        "filename": "Steller's_Jay_flagstaff_arizona.jpg",
+        "source": "wikipedia_infobox",
+        "license": "CC-BY-SA (Wikipedia)",
+        "wikipedia_page": "https://en.wikipedia.org/wiki/Steller%27s%20jay"
+      },
+      "wikipedia_audio": [
+        {
+          "url": "/content/audio/stja/wp_0.ogg",
+          "filename": "File:Cyanocitta stelleri - Steller's Jay - XC109654.ogg",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3ACyanocitta%20stelleri%20-%20Steller%27s%20Jay%20-%20XC109654.ogg"
+        }
+      ]
+    },
+    {
+      "id": "bewr",
+      "common_name": "Bewick's Wren",
+      "scientific_name": "Thryomanes bewickii",
+      "family": "Troglodytidae",
+      "ebird_frequency_pct": 26,
+      "habitat": [
+        "brush",
+        "backyard thickets",
+        "forest edge"
+      ],
+      "seasonality": "year-round",
+      "mnemonic": "Bright, complex buzzy song \u2014 like a miniature mockingbird with trills and buzzes",
+      "sound_types": {
+        "song": "Varied, complex song with clear whistles and buzzy trills",
+        "call": "Harsh scolding chatter when alarmed"
+      },
+      "confuser_species": [
+        "Pacific Wren",
+        "House Wren"
+      ],
+      "confuser_notes": "Pacific Wren is much faster and more cascading; House Wren is bubblier and less structured",
+      "xc_api_query": "https://xeno-canto.org/api/2/recordings?query=Thryomanes+bewickii+cnt:%22United+States%22+q:A",
+      "wikimedia_search": "https://commons.wikimedia.org/w/index.php?search=Bewick%27s+Wren+Thryomanes+bewickii&type=image",
+      "audio_clips": {
+        "songs": [
+          {
+            "xc_id": "490934",
+            "xc_url": "https://xeno-canto.org/490934",
+            "audio_url": "/content/audio/bewr/490934.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:21",
+            "recordist": "Steve Hampton",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Vashon, King County, Washington",
+            "country": "United States",
+            "score": 11
+          },
+          {
+            "xc_id": "784043",
+            "xc_url": "https://xeno-canto.org/784043",
+            "audio_url": "/content/audio/bewr/784043.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:46",
+            "recordist": "Whitney Neufeld-Kaiser",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Wedgwood, Seattle, King County, Washington",
+            "country": "United States",
+            "score": 10.5
+          },
+          {
+            "xc_id": "557838",
+            "xc_url": "https://xeno-canto.org/557838",
+            "audio_url": "/content/audio/bewr/557838.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:33",
+            "recordist": "Whitney Neufeld-Kaiser",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Arlington, Snohomish County, Washington",
+            "country": "United States",
+            "score": 10.5
+          }
+        ],
+        "calls": [
+          {
+            "xc_id": "584936",
+            "xc_url": "https://xeno-canto.org/584936",
+            "audio_url": "/content/audio/bewr/584936.ogg",
+            "type": "call",
+            "quality": "A",
+            "length": "0:49",
+            "recordist": "James Link",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Quilcene, Jefferson County, Washington",
+            "country": "United States",
+            "score": 10.5
+          },
+          {
+            "xc_id": "624555",
+            "xc_url": "https://xeno-canto.org/624555",
+            "audio_url": "/content/audio/bewr/624555.ogg",
+            "type": "call",
+            "quality": "A",
+            "length": "0:24",
+            "recordist": "Thomas Magarian",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Smith Bybee Wetlands, North Portland, Multnomah County, Oregon",
+            "country": "United States",
+            "score": 9
+          }
+        ]
+      },
+      "photo": {
+        "url": "/content/photos/bewr.jpg",
+        "width": 1746,
+        "height": 1746,
+        "filename": "Bewicks_Wren.jpg",
+        "source": "wikipedia_infobox",
+        "license": "CC-BY-SA (Wikipedia)",
+        "wikipedia_page": "https://en.wikipedia.org/wiki/Bewick%27s%20wren"
+      },
+      "wikipedia_audio": [
+        {
+          "url": "/content/audio/bewr/wp_0.ogg",
+          "filename": "File:Thryomanes bewickii - Bewick's Wren - XC109604.ogg",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3AThryomanes%20bewickii%20-%20Bewick%27s%20Wren%20-%20XC109604.ogg"
+        },
+        {
+          "url": "/content/audio/bewr/wp_1.ogg",
+          "filename": "File:Thryomanes bewickii - Bewick's Wren - XC109632.ogg",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3AThryomanes%20bewickii%20-%20Bewick%27s%20Wren%20-%20XC109632.ogg"
+        }
+      ]
+    },
+    {
+      "id": "anhu",
+      "common_name": "Anna's Hummingbird",
+      "scientific_name": "Calypte anna",
+      "family": "Trochilidae",
+      "ebird_frequency_pct": 26,
+      "habitat": [
+        "backyard",
+        "gardens",
+        "urban"
+      ],
+      "seasonality": "year-round",
+      "mnemonic": "Scratchy, buzzy, metallic series of chips and squeals \u2014 surprisingly loud for its size",
+      "sound_types": {
+        "song": "Complex scratchy buzzing and squealing song, often from an exposed perch",
+        "call": "Sharp chip note; also a loud chirp during dive display"
+      },
+      "confuser_species": [
+        "Rufous Hummingbird"
+      ],
+      "confuser_notes": "Rufous (seasonal visitor) has a simpler, lower-pitched buzz; Anna's song is longer and more complex",
+      "xc_api_query": "https://xeno-canto.org/api/2/recordings?query=Calypte+anna+cnt:%22United+States%22+q:A",
+      "wikimedia_search": "https://commons.wikimedia.org/w/index.php?search=Anna%27s+Hummingbird+Calypte+anna&type=image",
+      "audio_clips": {
+        "songs": [
+          {
+            "xc_id": "549602",
+            "xc_url": "https://xeno-canto.org/549602",
+            "audio_url": "/content/audio/anhu/549602.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:12",
+            "recordist": "Bruce Lagerquist",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Thornton Creek Ravine, Seattle, King County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "473411",
+            "xc_url": "https://xeno-canto.org/473411",
+            "audio_url": "/content/audio/anhu/473411.ogg",
+            "type": "flight call, song, display sound",
+            "quality": "A",
+            "length": "0:20",
+            "recordist": "bowtyler",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Olympia, Thurston County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "958844",
+            "xc_url": "https://xeno-canto.org/958844",
+            "audio_url": "/content/audio/anhu/958844.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:26",
+            "recordist": "Ayala Berger",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Arboretum Garden (near  Seattle), King County, Washington",
+            "country": "United States",
+            "score": 11
+          }
+        ],
+        "calls": [
+          {
+            "xc_id": "473411",
+            "xc_url": "https://xeno-canto.org/473411",
+            "audio_url": "/content/audio/anhu/473411.ogg",
+            "type": "flight call, song, display sound",
+            "quality": "A",
+            "length": "0:20",
+            "recordist": "bowtyler",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Olympia, Thurston County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "1080235",
+            "xc_url": "https://xeno-canto.org/1080235",
+            "audio_url": "/content/audio/anhu/1080235.ogg",
+            "type": "call, Dive-sound",
+            "quality": "A",
+            "length": "0:23",
+            "recordist": "Greg Irving",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Dungeness Recreation Area, Clallam County, Washington",
+            "country": "United States",
+            "score": 11
+          }
+        ]
+      },
+      "photo": {
+        "url": "/content/photos/anhu.jpg",
+        "width": 2763,
+        "height": 1784,
+        "filename": "Anna's_hummingbird.jpg",
+        "source": "wikipedia_infobox",
+        "license": "CC-BY-SA (Wikipedia)",
+        "wikipedia_page": "https://en.wikipedia.org/wiki/Anna%27s%20hummingbird"
+      },
+      "wikipedia_audio": [
+        {
+          "url": "/content/audio/anhu/wp_0.ogg",
+          "filename": "File:Calypte anna - Anna's Hummingbird - XC109651.ogg",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3ACalypte%20anna%20-%20Anna%27s%20Hummingbird%20-%20XC109651.ogg"
+        }
+      ]
+    },
+    {
+      "id": "cbch",
+      "common_name": "Chestnut-backed Chickadee",
+      "scientific_name": "Poecile rufescens",
+      "family": "Paridae",
+      "ebird_frequency_pct": 25,
+      "habitat": [
+        "coniferous forest",
+        "backyard",
+        "parkland"
+      ],
+      "seasonality": "year-round",
+      "mnemonic": "Faster, higher-pitched tsee-dee-dee than Black-capped \u2014 like a sped-up version",
+      "sound_types": {
+        "song": "Less distinct than Black-capped; doesn't give the clear fee-bee whistle",
+        "call": "Rapid, high tsee-dee-dee, faster and buzzier than Black-capped"
+      },
+      "confuser_species": [
+        "Black-capped Chickadee"
+      ],
+      "confuser_notes": "Key confuser pair \u2014 Black-capped is slower with clear fee-bee song; Chestnut-backed is higher and faster",
+      "xc_api_query": "https://xeno-canto.org/api/2/recordings?query=Poecile+rufescens+cnt:%22United+States%22+q:A",
+      "wikimedia_search": "https://commons.wikimedia.org/w/index.php?search=Chestnut-backed+Chickadee+Poecile+rufescens&type=image",
+      "audio_clips": {
+        "songs": [
+          {
+            "xc_id": "582163",
+            "xc_url": "https://xeno-canto.org/582163",
+            "audio_url": "/content/audio/cbch/582163.ogg",
+            "type": "call, song",
+            "quality": "A",
+            "length": "0:27",
+            "recordist": "James Link",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Center Road at Milepost 7.36 (across from Olympic Music Fest (near  Quilcene), Jefferson County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "1023857",
+            "xc_url": "https://xeno-canto.org/1023857",
+            "audio_url": "/content/audio/cbch/1023857.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:30",
+            "recordist": "Greg Irving",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Dungeness Trails, Sequim, Clallam County, Washington",
+            "country": "United States",
+            "score": 11
+          },
+          {
+            "xc_id": "420593",
+            "xc_url": "https://xeno-canto.org/420593",
+            "audio_url": "/content/audio/cbch/420593.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:14",
+            "recordist": "Meena Haribal",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Brinnon, Jefferson County, Washington",
+            "country": "United States",
+            "score": 11
+          }
+        ],
+        "calls": [
+          {
+            "xc_id": "582163",
+            "xc_url": "https://xeno-canto.org/582163",
+            "audio_url": "/content/audio/cbch/582163.ogg",
+            "type": "call, song",
+            "quality": "A",
+            "length": "0:27",
+            "recordist": "James Link",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Center Road at Milepost 7.36 (across from Olympic Music Fest (near  Quilcene), Jefferson County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "540321",
+            "xc_url": "https://xeno-canto.org/540321",
+            "audio_url": "/content/audio/cbch/540321.ogg",
+            "type": "alarm call",
+            "quality": "A",
+            "length": "0:27",
+            "recordist": "Whitney Neufeld-Kaiser",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Wedgwood, Seattle, King County, Washington",
+            "country": "United States",
+            "score": 11.5
+          }
+        ]
+      },
+      "photo": {
+        "url": "/content/photos/cbch.jpg",
+        "width": 2447,
+        "height": 1855,
+        "filename": "Chestnut-backed_Chickadee_2154ab_(cropped).jpg",
+        "source": "wikipedia_infobox",
+        "license": "CC-BY-SA (Wikipedia)",
+        "wikipedia_page": "https://en.wikipedia.org/wiki/Chestnut-backed%20chickadee"
+      }
+    },
+    {
+      "id": "bush",
+      "common_name": "Bushtit",
+      "scientific_name": "Psaltriparus minimus",
+      "family": "Aegithalidae",
+      "ebird_frequency_pct": 25,
+      "habitat": [
+        "brush",
+        "backyard",
+        "deciduous woodland"
+      ],
+      "seasonality": "year-round",
+      "mnemonic": "Tiny high-pitched tsit-tsit-tsit in constant flocks \u2014 sounds like a flock of squeaky toys",
+      "sound_types": {
+        "song": "N/A \u2014 Bushtits give contact calls rather than a true song",
+        "call": "Constant thin, high tsit-tsit-tsit contact calls from flock"
+      },
+      "confuser_species": [
+        "Golden-crowned Kinglet"
+      ],
+      "confuser_notes": "Kinglet is even higher-pitched with a sibilant see-see-see; Bushtit is slightly lower with a harder tsit quality",
+      "xc_api_query": "https://xeno-canto.org/api/2/recordings?query=Psaltriparus+minimus+cnt:%22United+States%22+q:A",
+      "wikimedia_search": "https://commons.wikimedia.org/w/index.php?search=American+Bushtit+Psaltriparus+minimus&type=image",
+      "audio_clips": {
+        "songs": [
+          {
+            "xc_id": "417736",
+            "xc_url": "https://xeno-canto.org/417736",
+            "audio_url": "/content/audio/bush/417736.ogg",
+            "type": "call, song",
+            "quality": "A",
+            "length": "0:19",
+            "recordist": "Paula Caycedo &amp; Mitch Covington",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Grand Canyon Village, Coconino County, Arizona",
+            "country": "United States",
+            "score": 7.5
+          },
+          {
+            "xc_id": "215759",
+            "xc_url": "https://xeno-canto.org/215759",
+            "audio_url": "/content/audio/bush/215759.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:11",
+            "recordist": "Ted Floyd",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Lafayette, Boulder, Colorado",
+            "country": "United States",
+            "score": 7.5
+          },
+          {
+            "xc_id": "215758",
+            "xc_url": "https://xeno-canto.org/215758",
+            "audio_url": "/content/audio/bush/215758.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:08",
+            "recordist": "Ted Floyd",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Lafayette, Boulder, Colorado",
+            "country": "United States",
+            "score": 7.5
+          }
+        ],
+        "calls": [
+          {
+            "xc_id": "1024967",
+            "xc_url": "https://xeno-canto.org/1024967",
+            "audio_url": "/content/audio/bush/1024967.ogg",
+            "type": "call",
+            "quality": "A",
+            "length": "0:47",
+            "recordist": "Greg Irving",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Dungeness Trails, Sequim, Clallam County, Washington",
+            "country": "United States",
+            "score": 10.5
+          },
+          {
+            "xc_id": "1012283",
+            "xc_url": "https://xeno-canto.org/1012283",
+            "audio_url": "/content/audio/bush/1012283.ogg",
+            "type": "call",
+            "quality": "B",
+            "length": "0:22",
+            "recordist": "Greg Irving",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "ODT Access - Runnion & Sawmill, Sequim, Clallam County, Washington",
+            "country": "United States",
+            "score": 9
+          }
+        ]
+      },
+      "photo": {
+        "url": "/content/photos/bush.jpg",
+        "width": 2868,
+        "height": 2294,
+        "filename": "BushtitMale.jpg",
+        "source": "wikipedia_infobox",
+        "license": "CC-BY-SA (Wikipedia)",
+        "wikipedia_page": "https://en.wikipedia.org/wiki/American%20bushtit"
+      },
+      "wikipedia_audio": [
+        {
+          "url": "/content/audio/bush/wp_0.ogg",
+          "filename": "File:Psaltriparus minimus (American Bushtit) vocalizations - pone.0027052.s004.oga",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3APsaltriparus%20minimus%20%28American%20Bushtit%29%20vocalizations%20-%20pone.0027052.s004.oga"
+        }
+      ]
+    },
+    {
+      "id": "gcsp",
+      "common_name": "Golden-crowned Sparrow",
+      "scientific_name": "Zonotrichia atricapilla",
+      "family": "Passerellidae",
+      "ebird_frequency_pct": 25,
+      "habitat": [
+        "brush",
+        "backyard",
+        "thickets"
+      ],
+      "seasonality": "winter visitor (Oct\u2013Apr)",
+      "mnemonic": "Oh dear me \u2014 three descending whistled notes, melancholy and clear",
+      "sound_types": {
+        "song": "Three clear descending whistles: oh-dear-me",
+        "call": "Sharp tsik note, similar to White-crowned Sparrow"
+      },
+      "confuser_species": [
+        "White-crowned Sparrow"
+      ],
+      "confuser_notes": "White-crowned has a more complex song with buzzy trills; Golden-crowned is simpler \u2014 just the 3 descending whistles",
+      "xc_api_query": "https://xeno-canto.org/api/2/recordings?query=Zonotrichia+atricapilla+cnt:%22United+States%22+q:A",
+      "wikimedia_search": "https://commons.wikimedia.org/w/index.php?search=Golden-crowned+Sparrow+Zonotrichia+atricapilla&type=image",
+      "audio_clips": {
+        "songs": [
+          {
+            "xc_id": "506204",
+            "xc_url": "https://xeno-canto.org/506204",
+            "audio_url": "/content/audio/gcsp/506204.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:25",
+            "recordist": "Bruce Lagerquist",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Yakima, Yakima County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "440249",
+            "xc_url": "https://xeno-canto.org/440249",
+            "audio_url": "/content/audio/gcsp/440249.ogg",
+            "type": "call, song",
+            "quality": "A",
+            "length": "0:18",
+            "recordist": "Rachel Hudson",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Chehalis, Lewis County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "680976",
+            "xc_url": "https://xeno-canto.org/680976",
+            "audio_url": "/content/audio/gcsp/680976.ogg",
+            "type": "song",
+            "quality": "A",
+            "length": "0:48",
+            "recordist": "Steve Hampton",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Port Townsend, Jefferson County, Washington",
+            "country": "United States",
+            "score": 10
+          }
+        ],
+        "calls": [
+          {
+            "xc_id": "440249",
+            "xc_url": "https://xeno-canto.org/440249",
+            "audio_url": "/content/audio/gcsp/440249.ogg",
+            "type": "call, song",
+            "quality": "A",
+            "length": "0:18",
+            "recordist": "Rachel Hudson",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Chehalis, Lewis County, Washington",
+            "country": "United States",
+            "score": 11.5
+          },
+          {
+            "xc_id": "697248",
+            "xc_url": "https://xeno-canto.org/697248",
+            "audio_url": "/content/audio/gcsp/697248.ogg",
+            "type": "alarm call",
+            "quality": "A",
+            "length": "0:42",
+            "recordist": "Greg Irving",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Wolf Creek Trail, Olympic National Park, Washington",
+            "country": "United States",
+            "score": 10.5
+          }
+        ]
+      },
+      "photo": {
+        "url": "/content/photos/gcsp.jpg",
+        "width": 4928,
+        "height": 3264,
+        "filename": "Zonotrichia_atricapilla_-British_Columbia,_Canada-8.jpg",
+        "source": "wikipedia_infobox",
+        "license": "CC-BY-SA (Wikipedia)",
+        "wikipedia_page": "https://en.wikipedia.org/wiki/Golden-crowned%20sparrow"
+      }
+    },
+    {
+      "id": "eust",
+      "common_name": "European Starling",
+      "scientific_name": "Sturnus vulgaris",
+      "family": "Sturnidae",
+      "ebird_frequency_pct": 25,
+      "habitat": [
+        "urban",
+        "backyard",
+        "buildings"
+      ],
+      "seasonality": "year-round",
+      "mnemonic": "Chattering mimic \u2014 whistles, clicks, squeals, and borrowed songs all jumbled together",
+      "sound_types": {
+        "song": "Long rambling series of whistles, clicks, rattles, and mimicked sounds",
+        "call": "Descending whistle; also a harsh chatter"
+      },
+      "confuser_species": [
+        "Northern Mockingbird"
+      ],
+      "confuser_notes": "Mockingbird (rare in Seattle) repeats phrases 3+ times; Starling jumbles everything without repeating",
+      "xc_api_query": "https://xeno-canto.org/api/2/recordings?query=Sturnus+vulgaris+cnt:%22United+States%22+q:A",
+      "wikimedia_search": "https://commons.wikimedia.org/w/index.php?search=European+Starling+Sturnus+vulgaris&type=image",
+      "audio_clips": {
+        "songs": [
+          {
+            "xc_id": "1065863",
+            "xc_url": "https://xeno-canto.org/1065863",
+            "audio_url": "/content/audio/eust/1065863.ogg",
+            "type": "call, imitation, song",
+            "quality": "A",
+            "length": "4:10",
+            "recordist": "Greg Irving",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "3 Crabs Road, Clallam County, Washington",
+            "country": "United States",
+            "score": 8.5
+          },
+          {
+            "xc_id": "584859",
+            "xc_url": "https://xeno-canto.org/584859",
+            "audio_url": "/content/audio/eust/584859.ogg",
+            "type": "song",
+            "quality": "B",
+            "length": "0:19",
+            "recordist": "Thomas Magarian",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Kelley Point Park, North Portland, Multnomah County, Oregon",
+            "country": "United States",
+            "score": 7
+          },
+          {
+            "xc_id": "697243",
+            "xc_url": "https://xeno-canto.org/697243",
+            "audio_url": "/content/audio/eust/697243.ogg",
+            "type": "song",
+            "quality": "B",
+            "length": "2:16",
+            "recordist": "Greg Irving",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Port Angeles, Clallam, Washington",
+            "country": "United States",
+            "score": 6
+          }
+        ],
+        "calls": [
+          {
+            "xc_id": "240287",
+            "xc_url": "https://xeno-canto.org/240287",
+            "audio_url": "/content/audio/eust/240287.ogg",
+            "type": "call",
+            "quality": "B",
+            "length": "0:10",
+            "recordist": "Samsonite",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Washington, District of Columbia, District of Columbia",
+            "country": "United States",
+            "score": 9.5
+          },
+          {
+            "xc_id": "445787",
+            "xc_url": "https://xeno-canto.org/445787",
+            "audio_url": "/content/audio/eust/445787.ogg",
+            "type": "call",
+            "quality": "B",
+            "length": "0:15",
+            "recordist": "Thomas ARMAND",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "location": "Washington, Prince George's County, District of Columbia",
+            "country": "United States",
+            "score": 9
+          }
+        ]
+      },
+      "photo": {
+        "url": "/content/photos/eust.jpg",
+        "width": 1776,
+        "height": 2372,
+        "filename": "Toulouse_-_Sturnus_vulgaris_-_2012-02-26_-_3.jpg",
+        "source": "wikipedia_infobox",
+        "license": "CC-BY-SA (Wikipedia)",
+        "wikipedia_page": "https://en.wikipedia.org/wiki/Common%20starling"
+      },
+      "wikipedia_audio": [
+        {
+          "url": "/content/audio/eust/wp_0.ogg",
+          "filename": "File:Common Starling (Sturnus vulgaris) (W1CDR0001431 BD8).ogg",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3ACommon%20Starling%20%28Sturnus%20vulgaris%29%20%28W1CDR0001431%20BD8%29.ogg"
+        },
+        {
+          "url": "/content/audio/eust/wp_1.ogg",
+          "filename": "File:Sturnus vulgaris.ogg",
+          "source": "wikimedia_commons",
+          "license": "CC (see Commons page)",
+          "commons_page": "https://commons.wikimedia.org/wiki/File%3ASturnus%20vulgaris.ogg"
+        }
+      ]
+    }
+  ],
+  "confuser_pairs": [
+    {
+      "pair": [
+        "bcch",
+        "cbch"
+      ],
+      "label": "Black-capped vs Chestnut-backed Chickadee",
+      "difficulty": "medium",
+      "key_difference": "Black-capped: slower dee-dee-dee + clear fee-bee song. Chestnut-backed: faster, higher, no fee-bee."
+    },
+    {
+      "pair": [
+        "sosp",
+        "gcsp"
+      ],
+      "label": "Song Sparrow vs Golden-crowned Sparrow",
+      "difficulty": "easy",
+      "key_difference": "Song Sparrow: 3 notes + complex trill. Golden-crowned: 3 pure descending whistles, no trill."
+    },
+    {
+      "pair": [
+        "amcr",
+        "stja"
+      ],
+      "label": "American Crow vs Steller's Jay",
+      "difficulty": "easy",
+      "key_difference": "Crow: clean caw-caw. Jay: harsh shack-shack, more grating and varied."
+    },
+    {
+      "pair": [
+        "deju",
+        "spto"
+      ],
+      "label": "Dark-eyed Junco vs Spotted Towhee",
+      "difficulty": "medium",
+      "key_difference": "Junco: even trill on one pitch. Towhee: 2 intro notes THEN a trill."
+    },
+    {
+      "pair": [
+        "hofi",
+        "sosp"
+      ],
+      "label": "House Finch vs Song Sparrow",
+      "difficulty": "hard",
+      "key_difference": "House Finch: continuous warble ending in buzz. Song Sparrow: structured 3-note opening."
+    }
+  ],
+  "lesson_plan": {
+    "description": "5 lessons of 3 birds each, ordered by distinctiveness (most distinctive first)",
+    "lessons": [
+      {
+        "lesson": 1,
+        "title": "The unmistakable three",
+        "species": [
+          "amcr",
+          "stja",
+          "nofl"
+        ],
+        "rationale": "Loud, distinctive, impossible to confuse with each other. Builds confidence."
+      },
+      {
+        "lesson": 2,
+        "title": "Backyard singers",
+        "species": [
+          "amro",
+          "bcch",
+          "spto"
+        ],
+        "rationale": "Classic songs you'll hear every morning. Introduces the fee-bee mnemonic."
+      },
+      {
+        "lesson": 3,
+        "title": "The sparrow start",
+        "species": [
+          "sosp",
+          "deju",
+          "gcsp"
+        ],
+        "rationale": "First confuser challenge \u2014 three sparrow-like species with distinct songs."
+      },
+      {
+        "lesson": 4,
+        "title": "Small and buzzy",
+        "species": [
+          "bewr",
+          "anhu",
+          "hofi"
+        ],
+        "rationale": "Complex songs that reward repeated listening. Wren vs finch structure."
+      },
+      {
+        "lesson": 5,
+        "title": "Flock sounds and mimics",
+        "species": [
+          "cbch",
+          "bush",
+          "eust"
+        ],
+        "rationale": "Contact calls and mimicry. Introduces the chickadee confuser pair."
+      }
+    ]
+  }
+}

--- a/birdsong/src/App.tsx
+++ b/birdsong/src/App.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+import { useAppStore } from './store/appStore';
+import { Navigation } from './components/shared/Navigation';
+import { LearnTab } from './components/learn/LearnTab';
+import { QuizTab } from './components/quiz/QuizTab';
+import { Dashboard } from './components/progress/Dashboard';
+import { CreditsPage } from './components/credits/CreditsPage';
+
+export default function App() {
+  const initialized = useAppStore((s) => s.initialized);
+  const error = useAppStore((s) => s.error);
+  const activeTab = useAppStore((s) => s.activeTab);
+  const activeLessonSession = useAppStore((s) => s.activeLessonSession);
+  const initialize = useAppStore((s) => s.initialize);
+
+  useEffect(() => {
+    initialize();
+  }, []);
+
+  if (!initialized) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <h1 className="text-3xl font-bold text-[var(--color-primary)] animate-pulse-subtle">
+          Birdsong
+        </h1>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full p-6 text-center">
+        <p className="text-lg text-[var(--color-error)] mb-4">{error}</p>
+        <button
+          onClick={initialize}
+          className="px-6 py-2 bg-[var(--color-primary)] text-white rounded-lg font-medium"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-hidden">
+        {activeTab === 'learn' && <LearnTab />}
+        {activeTab === 'quiz' && <QuizTab />}
+        {activeTab === 'progress' && <Dashboard />}
+        {activeTab === 'credits' && <CreditsPage />}
+      </div>
+      {!activeLessonSession && <Navigation />}
+    </div>
+  );
+}

--- a/birdsong/src/adapters/audio.ts
+++ b/birdsong/src/adapters/audio.ts
@@ -1,0 +1,96 @@
+export interface AudioPlayer {
+  play(url: string): Promise<void>;
+  stop(): void;
+  isPlaying(): boolean;
+  preload(url: string): Promise<void>;
+  onStateChange?: (playing: boolean) => void;
+}
+
+export class WebAudioPlayer implements AudioPlayer {
+  private ctx: AudioContext | null = null;
+  private source: AudioBufferSourceNode | null = null;
+  private cache = new Map<string, AudioBuffer>();
+  private _playing = false;
+  private currentUrl: string | null = null;
+  onStateChange?: (playing: boolean) => void;
+
+  private getCtx(): AudioContext {
+    if (!this.ctx) {
+      this.ctx = new AudioContext();
+    }
+    if (this.ctx.state === 'suspended') {
+      this.ctx.resume();
+    }
+    return this.ctx;
+  }
+
+  private setPlaying(v: boolean) {
+    this._playing = v;
+    this.onStateChange?.(v);
+  }
+
+  async preload(url: string): Promise<void> {
+    if (this.cache.has(url)) return;
+    try {
+      const resp = await fetch(url);
+      const arrayBuf = await resp.arrayBuffer();
+      const ctx = this.getCtx();
+      const buffer = await ctx.decodeAudioData(arrayBuf);
+      this.cache.set(url, buffer);
+    } catch {
+      // preloading is best-effort
+    }
+  }
+
+  async play(url: string): Promise<void> {
+    this.stop();
+    this.currentUrl = url;
+    this.setPlaying(true);
+
+    try {
+      let buffer = this.cache.get(url);
+      if (!buffer) {
+        const resp = await fetch(url);
+        const arrayBuf = await resp.arrayBuffer();
+        const ctx = this.getCtx();
+        buffer = await ctx.decodeAudioData(arrayBuf);
+        this.cache.set(url, buffer);
+      }
+
+      if (this.currentUrl !== url) return;
+
+      const ctx = this.getCtx();
+      const source = ctx.createBufferSource();
+      source.buffer = buffer;
+      source.connect(ctx.destination);
+      source.onended = () => {
+        if (this.currentUrl === url) {
+          this.setPlaying(false);
+          this.currentUrl = null;
+        }
+      };
+      this.source = source;
+      source.start(0);
+    } catch {
+      this.setPlaying(false);
+      this.currentUrl = null;
+    }
+  }
+
+  stop(): void {
+    if (this.source) {
+      try {
+        this.source.stop();
+      } catch {
+        // already stopped
+      }
+      this.source = null;
+    }
+    this.currentUrl = null;
+    this.setPlaying(false);
+  }
+
+  isPlaying(): boolean {
+    return this._playing;
+  }
+}

--- a/birdsong/src/adapters/storage.ts
+++ b/birdsong/src/adapters/storage.ts
@@ -1,0 +1,53 @@
+import Dexie from 'dexie';
+import type { UserProgress, ConfusionEvent } from '../core/types';
+
+export interface StorageAdapter {
+  getProgress(speciesId: string): Promise<UserProgress | undefined>;
+  saveProgress(progress: UserProgress): Promise<void>;
+  getAllProgress(): Promise<UserProgress[]>;
+  getConfusionLog(): Promise<ConfusionEvent[]>;
+  logConfusion(event: ConfusionEvent): Promise<void>;
+  clearAll(): Promise<void>;
+}
+
+class BirdsongDB extends Dexie {
+  progress!: Dexie.Table<UserProgress, string>;
+  confusions!: Dexie.Table<ConfusionEvent, number>;
+
+  constructor() {
+    super('birdsong');
+    this.version(1).stores({
+      progress: 'speciesId, state, nextReview',
+      confusions: '++id, timestamp, targetId, chosenId',
+    });
+  }
+}
+
+const db = new BirdsongDB();
+
+export class DexieStorage implements StorageAdapter {
+  async getProgress(speciesId: string): Promise<UserProgress | undefined> {
+    return db.progress.get(speciesId);
+  }
+
+  async saveProgress(progress: UserProgress): Promise<void> {
+    await db.progress.put(progress);
+  }
+
+  async getAllProgress(): Promise<UserProgress[]> {
+    return db.progress.toArray();
+  }
+
+  async getConfusionLog(): Promise<ConfusionEvent[]> {
+    return db.confusions.toArray();
+  }
+
+  async logConfusion(event: ConfusionEvent): Promise<void> {
+    await db.confusions.add(event);
+  }
+
+  async clearAll(): Promise<void> {
+    await db.progress.clear();
+    await db.confusions.clear();
+  }
+}

--- a/birdsong/src/components/credits/CreditsPage.tsx
+++ b/birdsong/src/components/credits/CreditsPage.tsx
@@ -1,0 +1,127 @@
+import { useAppStore } from '../../store/appStore';
+
+export function CreditsPage() {
+  const manifest = useAppStore((s) => s.manifest);
+  const setTab = useAppStore((s) => s.setTab);
+
+  if (!manifest) return null;
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center px-4 py-3 border-b border-[var(--color-bg-subtle)]">
+        <button onClick={() => setTab('learn')} className="text-sm text-[var(--color-text-muted)]">
+          ← Back
+        </button>
+        <h1 className="flex-1 text-center font-semibold">Credits & Attribution</h1>
+        <div className="w-12" />
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4 py-4 pb-24">
+        <p className="text-sm text-[var(--color-text-muted)] mb-6">
+          All audio and images are used under their respective licenses. 
+          Thank you to the recordists and photographers who make this app possible.
+        </p>
+
+        {manifest.species.map((sp) => (
+          <div key={sp.id} className="mb-6 pb-6 border-b border-[var(--color-bg-subtle)]">
+            <div className="flex items-center gap-3 mb-3">
+              {sp.photo?.url && (
+                <img
+                  src={sp.photo.url}
+                  alt={sp.common_name}
+                  className="w-10 h-10 rounded-lg object-cover"
+                />
+              )}
+              <div>
+                <h3 className="font-semibold">{sp.common_name}</h3>
+                <p className="text-xs text-[var(--color-text-muted)] italic">
+                  {sp.scientific_name}
+                </p>
+              </div>
+            </div>
+
+            <div className="ml-2 space-y-2">
+              <p className="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wide">
+                Audio Recordings
+              </p>
+              {[...sp.audio_clips.songs, ...sp.audio_clips.calls].map((clip) => (
+                <div key={clip.xc_id} className="text-xs text-[var(--color-text-muted)] pl-2">
+                  <p>
+                    {clip.type} by {clip.recordist} —{' '}
+                    <a
+                      href={clip.xc_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[var(--color-secondary)] underline"
+                    >
+                      XC {clip.xc_id}
+                    </a>
+                  </p>
+                  <p>{clip.location}</p>
+                  <p>
+                    <a
+                      href={clip.license}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[var(--color-secondary)] underline"
+                    >
+                      License
+                    </a>
+                  </p>
+                </div>
+              ))}
+
+              {sp.wikipedia_audio && sp.wikipedia_audio.length > 0 && (
+                <>
+                  <p className="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wide mt-3">
+                    Wikipedia Audio
+                  </p>
+                  {sp.wikipedia_audio.map((wa, i) => (
+                    <div key={i} className="text-xs text-[var(--color-text-muted)] pl-2">
+                      <p>
+                        <a
+                          href={wa.commons_page}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-[var(--color-secondary)] underline"
+                        >
+                          {wa.filename}
+                        </a>
+                      </p>
+                      <p>{wa.license}</p>
+                    </div>
+                  ))}
+                </>
+              )}
+
+              <p className="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wide mt-3">
+                Photo
+              </p>
+              <div className="text-xs text-[var(--color-text-muted)] pl-2">
+                <p>
+                  Source: {sp.photo.source} — {sp.photo.license}
+                </p>
+                <p>
+                  <a
+                    href={sp.photo.wikipedia_page}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[var(--color-secondary)] underline"
+                  >
+                    Wikipedia page
+                  </a>
+                </p>
+              </div>
+            </div>
+          </div>
+        ))}
+
+        <div className="mt-4 pt-4 border-t border-[var(--color-bg-subtle)] text-center text-xs text-[var(--color-text-muted)]">
+          <p>Birdsong v{manifest.version}</p>
+          <p className="mt-1">{manifest.region}</p>
+          <p className="mt-1">{manifest.target_species_count} species — Tier {manifest.tier}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/birdsong/src/components/learn/BirdCard.tsx
+++ b/birdsong/src/components/learn/BirdCard.tsx
@@ -1,0 +1,89 @@
+import type { Species } from '../../core/types';
+import { AudioButton } from '../shared/AudioButton';
+import { AttributionInfo } from '../shared/AttributionInfo';
+import { motion } from 'framer-motion';
+
+export function BirdCard({
+  species,
+  onSwipeNext,
+  onSwipePrev,
+  isFirst,
+  isLast,
+}: {
+  species: Species;
+  onSwipeNext: () => void;
+  onSwipePrev: () => void;
+  isFirst: boolean;
+  isLast: boolean;
+}) {
+  return (
+    <motion.div
+      className="absolute inset-0 flex flex-col bg-white rounded-2xl shadow-lg overflow-hidden"
+      drag="x"
+      dragConstraints={{ left: 0, right: 0 }}
+      dragElastic={0.7}
+      onDragEnd={(_, info) => {
+        if (info.offset.x < -100) {
+          onSwipeNext();
+        } else if (info.offset.x > 100 && !isFirst) {
+          onSwipePrev();
+        }
+      }}
+    >
+      <div className="relative h-[55%] bg-[var(--color-bg-subtle)]">
+        {species.photo?.url && (
+          <img
+            src={species.photo.url}
+            alt={species.common_name}
+            className="w-full h-full object-cover"
+          />
+        )}
+        <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent px-4 pb-3 pt-8">
+          <h2 className="text-white text-2xl font-bold">{species.common_name}</h2>
+        </div>
+        <div className="absolute top-3 right-3">
+          <AttributionInfo photo={species.photo} />
+        </div>
+      </div>
+
+      <div className="flex-1 p-4 flex flex-col gap-3 overflow-y-auto">
+        <p className="text-[var(--color-text-muted)] italic text-sm">
+          {species.scientific_name}
+        </p>
+
+        <div className="flex gap-2 flex-wrap">
+          {species.audio_clips.songs.length > 0 && (
+            <AudioButton clips={species.audio_clips.songs} label="Play Song" />
+          )}
+          {species.audio_clips.calls.length > 0 && (
+            <AudioButton clips={species.audio_clips.calls} label="Play Call" />
+          )}
+        </div>
+
+        <div className="bg-[var(--color-bg)] rounded-lg p-3">
+          <p className="text-sm text-[var(--color-text-muted)] leading-relaxed italic">
+            "{species.mnemonic}"
+          </p>
+        </div>
+
+        <div className="flex gap-1.5 flex-wrap">
+          {species.habitat.map((h) => (
+            <span
+              key={h}
+              className="px-2.5 py-0.5 text-xs rounded-full bg-[var(--color-secondary-light)]/20 text-[var(--color-secondary-dark)]"
+            >
+              {h}
+            </span>
+          ))}
+        </div>
+
+        <div className="mt-auto flex justify-between items-center text-sm text-[var(--color-text-muted)] pt-2">
+          {!isFirst && <span>← Previous</span>}
+          <span className={isFirst ? '' : 'mx-auto'}>
+            {isLast ? 'Tap → to start quiz' : 'Swipe → Next'}
+          </span>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/birdsong/src/components/learn/IntroQuiz.tsx
+++ b/birdsong/src/components/learn/IntroQuiz.tsx
@@ -1,0 +1,141 @@
+import { useState, useRef, useCallback, useMemo } from 'react';
+import type { IntroQuizItem, ReviewQuizItem } from '../../core/types';
+import { AudioButton } from '../shared/AudioButton';
+
+type QuizItem = IntroQuizItem | ReviewQuizItem;
+
+export function IntroQuiz({
+  items,
+  onComplete,
+}: {
+  items: QuizItem[];
+  onComplete: (results: boolean[]) => void;
+}) {
+  const [index, setIndex] = useState(0);
+  const [results, setResults] = useState<boolean[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [answered, setAnswered] = useState(false);
+  const resultsRef = useRef<boolean[]>([]);
+  const indexRef = useRef(0);
+
+  const item = items[index];
+  if (!item) {
+    return null;
+  }
+
+  const choices = useMemo(
+    () => [item.targetSpecies, ...item.distractors].sort(() => Math.random() - 0.5),
+    [item.targetSpecies, item.distractors]
+  );
+
+  const advance = useCallback(() => {
+    const curIndex = indexRef.current;
+    const curResults = resultsRef.current;
+    if (curIndex + 1 >= items.length) {
+      onComplete(curResults);
+    } else {
+      indexRef.current = curIndex + 1;
+      setIndex(curIndex + 1);
+      setSelected(null);
+      setAnswered(false);
+    }
+  }, [items.length, onComplete]);
+
+  const handleSelect = (speciesId: string) => {
+    if (answered) return;
+    const correct = speciesId === item.targetSpecies.id;
+    setSelected(speciesId);
+    setAnswered(true);
+    const newResults = [...resultsRef.current, correct];
+    resultsRef.current = newResults;
+    setResults(newResults);
+
+    if (correct) {
+      setTimeout(advance, 1500);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full p-4 pb-20">
+      <div className="text-center mb-4">
+        <p className="text-[var(--color-text-muted)] text-sm mb-2">
+          Question {index + 1} of {items.length}
+        </p>
+        <AudioButton clips={[item.clip]} label="Play Sound" autoPlay />
+      </div>
+
+      <p className="text-center text-lg font-medium mb-4">Which bird is this?</p>
+
+      <div className="flex flex-col gap-3 flex-1">
+        {choices.map((sp) => {
+          let bgClass = 'bg-white border-[var(--color-bg-subtle)]';
+          if (answered) {
+            if (sp.id === item.targetSpecies.id) {
+              bgClass = 'bg-[var(--color-success-light)] border-[var(--color-success)]';
+            } else if (sp.id === selected) {
+              bgClass = 'bg-[var(--color-error-light)] border-[var(--color-error)]';
+            }
+          }
+
+          return (
+            <button
+              key={sp.id}
+              onClick={() => handleSelect(sp.id)}
+              disabled={answered}
+              className={`flex items-center gap-3 p-3 rounded-xl border-2 transition-all ${bgClass} ${
+                !answered ? 'hover:border-[var(--color-primary)] active:scale-[0.98]' : ''
+              }`}
+            >
+              {sp.photo?.url && (
+                <img
+                  src={sp.photo.url}
+                  alt={sp.common_name}
+                  className="w-12 h-12 rounded-lg object-cover"
+                />
+              )}
+              <div className="text-left">
+                <p className="font-medium text-sm">{sp.common_name}</p>
+                {answered && sp.id === item.targetSpecies.id && (
+                  <p className="text-xs text-[var(--color-success)] italic mt-0.5">
+                    "{item.targetSpecies.mnemonic}"
+                  </p>
+                )}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {answered && selected !== item.targetSpecies.id && (
+        <div className="mt-4 text-center">
+          <p className="text-sm text-[var(--color-error)] mb-2">
+            The correct answer is {item.targetSpecies.common_name}
+          </p>
+          <button
+            onClick={advance}
+            className="px-6 py-2 bg-[var(--color-primary)] text-white rounded-lg font-medium"
+          >
+            Next
+          </button>
+        </div>
+      )}
+
+      <div className="flex gap-1.5 justify-center mt-4">
+        {items.map((_, i) => (
+          <div
+            key={i}
+            className={`w-2 h-2 rounded-full ${
+              i < results.length
+                ? results[i]
+                  ? 'bg-[var(--color-success)]'
+                  : 'bg-[var(--color-error)]'
+                : i === index
+                ? 'bg-[var(--color-primary)]'
+                : 'bg-[var(--color-bg-subtle)]'
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/birdsong/src/components/learn/LearnSession.tsx
+++ b/birdsong/src/components/learn/LearnSession.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import type { Lesson, LessonPhase, IntroQuizItem, ReviewQuizItem } from '../../core/types';
+import { BirdCard } from './BirdCard';
+import { IntroQuiz } from './IntroQuiz';
+import { useAppStore } from '../../store/appStore';
+import { getSpeciesByIds } from '../../core/manifest';
+import { buildIntroQuiz, buildReviewQuiz } from '../../core/lesson';
+import { AnimatePresence, motion } from 'framer-motion';
+
+export function LearnSession({ lesson }: { lesson: Lesson }) {
+  const manifest = useAppStore((s) => s.manifest);
+  const introduceSpecies = useAppStore((s) => s.introduceSpecies);
+  const setActiveLessonSession = useAppStore((s) => s.setActiveLessonSession);
+  const initializedSpecies = useAppStore((s) => s.initializedSpecies);
+  const lastPlayedClipId = useAppStore((s) => s.lastPlayedClipId);
+  const setTab = useAppStore((s) => s.setTab);
+
+  const lessonSpecies = manifest ? getSpeciesByIds(manifest, lesson.species) : [];
+
+  const hasPriorSpecies = initializedSpecies().length > 0;
+  const [phase, setPhase] = useState<LessonPhase>(
+    hasPriorSpecies ? 'review' : 'cards'
+  );
+  const [cardIndex, setCardIndex] = useState(0);
+  const [reviewItems] = useState<ReviewQuizItem[]>(() =>
+    hasPriorSpecies ? buildReviewQuiz(initializedSpecies(), lastPlayedClipId) : []
+  );
+
+  const introItems: IntroQuizItem[] = manifest
+    ? buildIntroQuiz(lesson, initializedSpecies(), manifest.species, lastPlayedClipId)
+    : [];
+
+  const handleReviewComplete = () => {
+    setPhase('cards');
+  };
+
+  const handleCardNext = () => {
+    if (cardIndex + 1 < lessonSpecies.length) {
+      setCardIndex((i) => i + 1);
+    } else {
+      setPhase('quiz');
+    }
+  };
+
+  const handleCardPrev = () => {
+    if (cardIndex > 0) {
+      setCardIndex((i) => i - 1);
+    }
+  };
+
+  const handleIntroQuizComplete = async (_results: boolean[]) => {
+    await introduceSpecies(lesson.species);
+    setActiveLessonSession(null);
+    setTab('learn');
+  };
+
+  const handleExit = () => {
+    setActiveLessonSession(null);
+    setTab('learn');
+  };
+
+  return (
+    <div className="flex flex-col h-full relative">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--color-bg-subtle)]">
+        <button onClick={handleExit} className="text-[var(--color-text-muted)] text-sm">
+          ← Exit
+        </button>
+        <h2 className="font-semibold text-sm">{lesson.title}</h2>
+        <span className="text-xs text-[var(--color-text-muted)]">
+          {phase === 'review'
+            ? 'Warm-up'
+            : phase === 'cards'
+            ? `${cardIndex + 1}/${lessonSpecies.length}`
+            : 'Quiz'}
+        </span>
+      </div>
+
+      <div className="flex-1 relative overflow-hidden">
+        <AnimatePresence mode="wait">
+          {phase === 'review' && (
+            <motion.div
+              key="review"
+              initial={{ opacity: 0, x: 50 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -50 }}
+              className="absolute inset-0"
+            >
+              <IntroQuiz items={reviewItems} onComplete={handleReviewComplete} />
+            </motion.div>
+          )}
+
+          {phase === 'cards' && lessonSpecies[cardIndex] && (
+            <motion.div
+              key={`card-${cardIndex}`}
+              initial={{ opacity: 0, x: 50 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -50 }}
+              className="absolute inset-0 p-4"
+            >
+              <BirdCard
+                species={lessonSpecies[cardIndex]}
+                onSwipeNext={handleCardNext}
+                onSwipePrev={handleCardPrev}
+                isFirst={cardIndex === 0}
+                isLast={cardIndex === lessonSpecies.length - 1}
+              />
+            </motion.div>
+          )}
+
+          {phase === 'quiz' && (
+            <motion.div
+              key="quiz"
+              initial={{ opacity: 0, x: 50 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -50 }}
+              className="absolute inset-0"
+            >
+              <IntroQuiz items={introItems} onComplete={handleIntroQuizComplete} />
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/birdsong/src/components/learn/LearnTab.tsx
+++ b/birdsong/src/components/learn/LearnTab.tsx
@@ -1,0 +1,108 @@
+import { useAppStore } from '../../store/appStore';
+import { getLessons } from '../../core/manifest';
+import { isLessonAvailable, isLessonComplete, getCompletedLessonNums } from '../../core/lesson';
+import { LearnSession } from './LearnSession';
+
+export function LearnTab() {
+  const manifest = useAppStore((s) => s.manifest);
+  const allProgress = useAppStore((s) => s.allProgress);
+  const activeLessonSession = useAppStore((s) => s.activeLessonSession);
+
+  if (!manifest) return null;
+
+  if (activeLessonSession) {
+    return <LearnSession lesson={activeLessonSession.lesson} />;
+  }
+
+  const lessons = getLessons(manifest);
+  const completedNums = getCompletedLessonNums(lessons, allProgress);
+  const introducedCount = manifest.species.filter(
+    (sp) => allProgress.get(sp.id)?.introduced
+  ).length;
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-4 pt-4 pb-2">
+        <h1 className="text-xl font-bold text-[var(--color-text)]">Birdsong</h1>
+        <p className="text-sm text-[var(--color-text-muted)] mt-1">
+          {introducedCount}/{manifest.target_species_count} birds learned
+        </p>
+        <div className="mt-2 h-2 bg-[var(--color-bg-subtle)] rounded-full overflow-hidden">
+          <div
+            className="h-full bg-[var(--color-secondary)] rounded-full transition-all duration-500"
+            style={{ width: `${(introducedCount / manifest.target_species_count) * 100}%` }}
+          />
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4 py-2 pb-24">
+        {lessons.map((lesson) => {
+          const complete = isLessonComplete(lesson, allProgress);
+          const available = isLessonAvailable(lesson.lesson, completedNums, allProgress);
+          const lessonSpecies = manifest.species.filter((sp) =>
+            lesson.species.includes(sp.id)
+          );
+
+          return (
+            <button
+              key={lesson.lesson}
+              disabled={!available && !complete}
+              onClick={() => {
+                if (available && !complete) {
+                  useAppStore.getState().setActiveLessonSession({
+                    lesson,
+                    phase: 'cards',
+                    cardIndex: 0,
+                    introQuizItems: [],
+                    reviewQuizItems: [],
+                    quizIndex: 0,
+                    quizResults: [],
+                  });
+                }
+              }}
+              className={`w-full mb-3 p-4 rounded-xl border-2 text-left transition-all ${
+                complete
+                  ? 'bg-[var(--color-success-light)] border-[var(--color-success)]'
+                  : available
+                  ? 'bg-white border-[var(--color-primary)] hover:shadow-md'
+                  : 'bg-[var(--color-bg-subtle)] border-transparent opacity-60'
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-xs text-[var(--color-text-muted)] uppercase tracking-wide">
+                    Lesson {lesson.lesson}
+                  </p>
+                  <h3 className="font-semibold mt-0.5">{lesson.title}</h3>
+                  <p className="text-xs text-[var(--color-text-muted)] mt-1">
+                    {lesson.rationale}
+                  </p>
+                </div>
+                <div className="text-xl">
+                  {complete ? '✓' : available ? '→' : '🔒'}
+                </div>
+              </div>
+
+              <div className="flex gap-2 mt-3">
+                {lessonSpecies.map((sp) => (
+                  <div key={sp.id} className="flex flex-col items-center">
+                    {sp.photo?.url && (
+                      <img
+                        src={sp.photo.url}
+                        alt={sp.common_name}
+                        className="w-10 h-10 rounded-full object-cover border border-[var(--color-bg-subtle)]"
+                      />
+                    )}
+                    <span className="text-[10px] text-[var(--color-text-muted)] mt-0.5 text-center leading-tight">
+                      {sp.common_name.split(' ').pop()}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/birdsong/src/components/progress/Dashboard.tsx
+++ b/birdsong/src/components/progress/Dashboard.tsx
@@ -1,0 +1,118 @@
+import { useAppStore } from '../../store/appStore';
+import { countDue } from '../../core/quiz';
+import { getNextReviewDate } from '../../core/fsrs';
+
+export function Dashboard() {
+  const manifest = useAppStore((s) => s.manifest);
+  const allProgress = useAppStore((s) => s.allProgress);
+  const setTab = useAppStore((s) => s.setTab);
+
+  if (!manifest) return null;
+
+  const introduced = manifest.species.filter(
+    (sp) => allProgress.get(sp.id)?.introduced
+  ).length;
+  const inReview = manifest.species.filter(
+    (sp) => allProgress.get(sp.id)?.state === 'review'
+  ).length;
+  const dueCount = countDue(allProgress);
+
+  const stateBadge = (state: string) => {
+    switch (state) {
+      case 'new':
+        return 'bg-gray-100 text-gray-600';
+      case 'learning':
+        return 'bg-yellow-100 text-yellow-700';
+      case 'review':
+        return 'bg-green-100 text-green-700';
+      case 'relearning':
+        return 'bg-red-100 text-red-700';
+      default:
+        return 'bg-gray-100 text-gray-600';
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-4 pt-4 pb-3 border-b border-[var(--color-bg-subtle)]">
+        <h1 className="text-xl font-bold mb-3">Progress</h1>
+        <div className="flex gap-3 text-sm">
+          <div className="flex-1 bg-[var(--color-bg)] rounded-lg p-3 text-center">
+            <p className="text-2xl font-bold text-[var(--color-secondary)]">{introduced}</p>
+            <p className="text-[var(--color-text-muted)]">learned</p>
+          </div>
+          <div className="flex-1 bg-[var(--color-bg)] rounded-lg p-3 text-center">
+            <p className="text-2xl font-bold text-[var(--color-primary)]">{inReview}</p>
+            <p className="text-[var(--color-text-muted)]">in review</p>
+          </div>
+          <div className="flex-1 bg-[var(--color-bg)] rounded-lg p-3 text-center">
+            <p className="text-2xl font-bold">{dueCount}</p>
+            <p className="text-[var(--color-text-muted)]">due now</p>
+          </div>
+        </div>
+        {dueCount > 0 && (
+          <button
+            onClick={() => setTab('quiz')}
+            className="w-full mt-3 py-2 bg-[var(--color-primary)] text-white rounded-lg font-medium text-sm"
+          >
+            Start Review ({dueCount})
+          </button>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4 py-2 pb-24">
+        {manifest.species.map((sp) => {
+          const progress = allProgress.get(sp.id);
+          const state = progress?.state ?? 'new';
+          const nextDate = progress ? getNextReviewDate(progress) : null;
+
+          return (
+            <div
+              key={sp.id}
+              className="flex items-center gap-3 py-3 border-b border-[var(--color-bg-subtle)]"
+            >
+              {sp.photo?.url && (
+                <img
+                  src={sp.photo.url}
+                  alt={sp.common_name}
+                  className="w-10 h-10 rounded-full object-cover"
+                />
+              )}
+              <div className="flex-1 min-w-0">
+                <p className="font-medium text-sm truncate">{sp.common_name}</p>
+                <p className="text-xs text-[var(--color-text-muted)]">
+                  {progress?.introduced
+                    ? nextDate
+                      ? nextDate <= new Date()
+                        ? 'Due now'
+                        : `Review ${formatRelativeDate(nextDate)}`
+                      : 'Not started'
+                    : 'Not started'}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                {progress && progress.reps > 0 && (
+                  <span className="text-xs text-[var(--color-text-muted)]">
+                    {progress.reps} reps
+                  </span>
+                )}
+                <span className={`px-2 py-0.5 text-xs rounded-full font-medium ${stateBadge(state)}`}>
+                  {state}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function formatRelativeDate(date: Date): string {
+  const diff = date.getTime() - Date.now();
+  const hours = Math.round(diff / (1000 * 60 * 60));
+  if (hours < 1) return 'soon';
+  if (hours < 24) return `in ${hours}h`;
+  const days = Math.round(hours / 24);
+  return `in ${days}d`;
+}

--- a/birdsong/src/components/quiz/QuizResult.tsx
+++ b/birdsong/src/components/quiz/QuizResult.tsx
@@ -1,0 +1,55 @@
+export function QuizResult({
+  results,
+  againSpecies,
+  nextReviewCount,
+  onClose,
+}: {
+  results: boolean[];
+  againSpecies: string[];
+  nextReviewCount: number;
+  onClose: () => void;
+}) {
+  const correct = results.filter(Boolean).length;
+  const total = results.length;
+  const pct = Math.round((correct / total) * 100);
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full p-6">
+      <div className="text-6xl mb-4">
+        {pct >= 80 ? '🎉' : pct >= 50 ? '👍' : '📚'}
+      </div>
+      <h2 className="text-2xl font-bold mb-2">
+        {correct}/{total} correct
+      </h2>
+      <p className="text-[var(--color-text-muted)] mb-6">
+        {pct >= 80 ? 'Great work!' : pct >= 50 ? 'Keep practicing!' : 'Review time!'}
+      </p>
+
+      {againSpecies.length > 0 && (
+        <div className="w-full mb-6 p-4 bg-[var(--color-error-light)] rounded-xl">
+          <p className="text-sm font-medium text-[var(--color-error)] mb-2">
+            Needs more practice:
+          </p>
+          <ul className="text-sm text-[var(--color-error)]">
+            {againSpecies.map((name) => (
+              <li key={name}>{name}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <p className="text-sm text-[var(--color-text-muted)] mb-6">
+        {nextReviewCount > 0
+          ? `${nextReviewCount} bird${nextReviewCount > 1 ? 's' : ''} due for review soon`
+          : 'No reviews due right now'}
+      </p>
+
+      <button
+        onClick={onClose}
+        className="px-8 py-3 bg-[var(--color-primary)] text-white rounded-xl font-semibold text-lg"
+      >
+        Back to Home
+      </button>
+    </div>
+  );
+}

--- a/birdsong/src/components/quiz/QuizSession.tsx
+++ b/birdsong/src/components/quiz/QuizSession.tsx
@@ -1,0 +1,151 @@
+import { useState, useRef } from 'react';
+import type { QuizItem } from '../../core/types';
+import { ThreeChoiceQuiz } from './ThreeChoiceQuiz';
+import { SameDifferent } from './SameDifferent';
+import { QuizResult } from './QuizResult';
+import { useAppStore } from '../../store/appStore';
+import { scheduleReview, ratingFromOutcome, ratingFromOutcomeSameDifferent } from '../../core/fsrs';
+import { buildQuizSession, countDue } from '../../core/quiz';
+import { getInTierConfuserPairs } from '../../core/manifest';
+import { AnimatePresence, motion } from 'framer-motion';
+import type { Grade } from 'ts-fsrs';
+
+export function QuizSession() {
+  const manifest = useAppStore((s) => s.manifest);
+  const allProgress = useAppStore((s) => s.allProgress);
+  const updateProgress = useAppStore((s) => s.updateProgress);
+  const logConfusion = useAppStore((s) => s.logConfusion);
+  const lastPlayedClipId = useAppStore((s) => s.lastPlayedClipId);
+  const setTab = useAppStore((s) => s.setTab);
+  const initializedSpecies = useAppStore((s) => s.initializedSpecies);
+
+  const [items] = useState<QuizItem[]>(() => {
+    if (!manifest) return [];
+    const confuserPairs = getInTierConfuserPairs(manifest);
+    const introduced = initializedSpecies();
+    return buildQuizSession(allProgress, introduced, confuserPairs, lastPlayedClipId);
+  });
+
+  const [index, setIndex] = useState(0);
+  const [results, setResults] = useState<boolean[]>([]);
+  const [againSpecies, setAgainSpecies] = useState<string[]>([]);
+  const [done, setDone] = useState(false);
+  const startTimeRef = useRef(Date.now());
+
+  if (!manifest || items.length === 0) return null;
+
+  const handleAnswer = async (correct: boolean, responseTimeMs: number) => {
+    const item = items[index];
+    const progress = allProgress.get(item.targetSpecies.id);
+    if (!progress) return;
+
+    const rating: Grade = item.exerciseType === 'same_different'
+      ? ratingFromOutcomeSameDifferent(correct, responseTimeMs)
+      : ratingFromOutcome(correct, responseTimeMs);
+
+    const updated = scheduleReview(progress, rating);
+    await updateProgress(item.targetSpecies.id, updated);
+
+    if (!correct) {
+      setAgainSpecies((prev) =>
+        prev.includes(item.targetSpecies.common_name)
+          ? prev
+          : [...prev, item.targetSpecies.common_name]
+      );
+      await logConfusion(item.targetSpecies.id, item.targetSpecies.id);
+    }
+
+    setResults((prev) => [...prev, correct]);
+  };
+
+  const handleAdvance = () => {
+    if (index + 1 >= items.length) {
+      setDone(true);
+    } else {
+      setIndex((i) => i + 1);
+      startTimeRef.current = Date.now();
+    }
+  };
+
+  if (done) {
+    const dueNow = countDue(allProgress);
+    return (
+      <QuizResult
+        results={results}
+        againSpecies={againSpecies}
+        nextReviewCount={dueNow}
+        onClose={() => setTab('quiz')}
+      />
+    );
+  }
+
+  const item = items[index];
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--color-bg-subtle)]">
+        <span className="text-sm text-[var(--color-text-muted)]">
+          {index + 1}/{items.length}
+        </span>
+        <div className="flex gap-1.5">
+          {results.map((r, i) => (
+            <div
+              key={i}
+              className={`w-2 h-2 rounded-full ${
+                r ? 'bg-[var(--color-success)]' : 'bg-[var(--color-error)]'
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="flex-1 relative">
+        <AnimatePresence mode="wait">
+          {item.exerciseType === 'three_choice' ? (
+            <motion.div
+              key={`tc-${index}`}
+              initial={{ opacity: 0, x: 50 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -50 }}
+              className="absolute inset-0"
+            >
+              <ThreeChoiceQuiz
+                item={item}
+                onAnswer={(correct, time) => {
+                  handleAnswer(correct, time);
+                  if (correct) setTimeout(handleAdvance, 1500);
+                }}
+              />
+              {!results[index] && results.length > index && (
+                <div className="absolute bottom-4 left-0 right-0 text-center">
+                  <button
+                    onClick={handleAdvance}
+                    className="px-6 py-2 bg-[var(--color-primary)] text-white rounded-lg font-medium"
+                  >
+                    Next
+                  </button>
+                </div>
+              )}
+            </motion.div>
+          ) : (
+            <motion.div
+              key={`sd-${index}`}
+              initial={{ opacity: 0, x: 50 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -50 }}
+              className="absolute inset-0"
+            >
+              <SameDifferent
+                item={item}
+                onAnswer={(correct, time) => {
+                  handleAnswer(correct, time);
+                  setTimeout(handleAdvance, correct ? 1500 : 2500);
+                }}
+              />
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/birdsong/src/components/quiz/QuizTab.tsx
+++ b/birdsong/src/components/quiz/QuizTab.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import { useAppStore } from '../../store/appStore';
+import { countDue, hasRelearning } from '../../core/quiz';
+import { QuizSession } from './QuizSession';
+import type { UserProgress } from '../../core/types';
+
+export function QuizTab() {
+  const allProgress = useAppStore((s) => s.allProgress);
+  const setTab = useAppStore((s) => s.setTab);
+  const initializedSpecies = useAppStore((s) => s.initializedSpecies);
+
+  const [quizzing, setQuizzing] = useState(false);
+
+  if (quizzing) {
+    return <QuizSession />;
+  }
+
+  const introduced = initializedSpecies();
+  const dueCount = countDue(allProgress);
+  const relearning = hasRelearning(allProgress);
+
+  if (introduced.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full p-6 text-center">
+        <div className="text-5xl mb-4">🐣</div>
+        <h2 className="text-xl font-bold mb-2">No birds learned yet</h2>
+        <p className="text-[var(--color-text-muted)] mb-6">
+          Start learning birds to unlock quizzes!
+        </p>
+        <button
+          onClick={() => setTab('learn')}
+          className="px-6 py-3 bg-[var(--color-primary)] text-white rounded-xl font-semibold"
+        >
+          Learn Birds
+        </button>
+      </div>
+    );
+  }
+
+  if (dueCount === 0) {
+    const nextReview = findNextReview(allProgress);
+
+    return (
+      <div className="flex flex-col items-center justify-center h-full p-6 text-center">
+        <div className="text-5xl mb-4">✨</div>
+        <h2 className="text-xl font-bold mb-2">All caught up!</h2>
+        {nextReview && (
+          <p className="text-[var(--color-text-muted)] mb-4">
+            Next review: {formatRelativeDate(nextReview)}
+          </p>
+        )}
+        {relearning ? (
+          <p className="text-sm text-[var(--color-error)]">
+            Some birds need more practice. Keep reviewing!
+          </p>
+        ) : (
+          <button
+            onClick={() => setTab('learn')}
+            className="px-6 py-3 bg-[var(--color-secondary)] text-white rounded-xl font-semibold"
+          >
+            Learn More Birds
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full p-6 text-center">
+      <div className="text-5xl mb-4">🎯</div>
+      <h2 className="text-xl font-bold mb-2">
+        {dueCount} bird{dueCount > 1 ? 's' : ''} to review
+      </h2>
+      <p className="text-[var(--color-text-muted)] mb-6">
+        Test your knowledge with spaced repetition
+      </p>
+      <button
+        onClick={() => setQuizzing(true)}
+        className="px-8 py-3 bg-[var(--color-primary)] text-white rounded-xl font-semibold text-lg"
+      >
+        Start Review
+      </button>
+    </div>
+  );
+}
+
+function findNextReview(allProgress: Map<string, UserProgress>): Date | null {
+  let earliest: Date | null = null;
+  for (const p of allProgress.values()) {
+    if (!p.introduced || !p.nextReview) continue;
+    if (p.nextReview <= Date.now()) continue;
+    const d = new Date(p.nextReview);
+    if (!earliest || d < earliest) earliest = d;
+  }
+  return earliest;
+}
+
+function formatRelativeDate(date: Date): string {
+  const diff = date.getTime() - Date.now();
+  const hours = Math.round(diff / (1000 * 60 * 60));
+  if (hours < 1) return 'soon';
+  if (hours < 24) return `in ${hours} hour${hours > 1 ? 's' : ''}`;
+  const days = Math.round(hours / 24);
+  return `in ${days} day${days > 1 ? 's' : ''}`;
+}

--- a/birdsong/src/components/quiz/SameDifferent.tsx
+++ b/birdsong/src/components/quiz/SameDifferent.tsx
@@ -1,0 +1,139 @@
+import { useState, useRef, useEffect, useMemo } from 'react';
+import type { QuizItem, Species } from '../../core/types';
+import { useAppStore } from '../../store/appStore';
+
+export function SameDifferent({
+  item,
+  onAnswer,
+}: {
+  item: QuizItem;
+  onAnswer: (correct: boolean, responseTimeMs: number) => void;
+}) {
+  const audioPlayer = useAppStore((s) => s.audioPlayer);
+  const manifest = useAppStore((s) => s.manifest);
+  const [phase, setPhase] = useState<'playing1' | 'gap' | 'playing2' | 'answering'>('playing1');
+  const [selected, setSelected] = useState<boolean | null>(null);
+  const [answered, setAnswered] = useState(false);
+  const timerRef = useRef<number | null>(null);
+  const startTimeRef = useRef(0);
+
+  const secondSpecies: Species | undefined = useMemo(() => {
+    if (item.isSame || !item.secondClip || !manifest) return item.targetSpecies;
+    return manifest.species.find(
+      (s) =>
+        s.audio_clips.songs.some((c) => c.audio_url === item.secondClip!.audio_url) ||
+        s.audio_clips.calls.some((c) => c.audio_url === item.secondClip!.audio_url)
+    );
+  }, [item.isSame, item.secondClip, manifest, item.targetSpecies]);
+
+  useEffect(() => {
+    playSequence();
+    return () => {
+      audioPlayer.stop();
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const playSequence = async () => {
+    setPhase('playing1');
+    await audioPlayer.play(item.clip.audio_url);
+
+    setPhase('gap');
+    await new Promise<void>((resolve) => {
+      timerRef.current = window.setTimeout(() => resolve(), 1500);
+    });
+
+    setPhase('playing2');
+    if (item.secondClip) {
+      await audioPlayer.play(item.secondClip.audio_url);
+    }
+
+    setPhase('answering');
+    startTimeRef.current = Date.now();
+  };
+
+  const handleAnswer = (same: boolean) => {
+    if (answered) return;
+    const responseTime = Date.now() - startTimeRef.current;
+    const correct = same === item.isSame;
+    setSelected(same);
+    setAnswered(true);
+    onAnswer(correct, responseTime);
+  };
+
+  const clipLabel = phase === 'playing1' ? 'Clip 1 of 2' : phase === 'playing2' ? 'Clip 2 of 2' : '';
+
+  return (
+    <div className="flex flex-col h-full p-4">
+      <div className="text-center mb-4">
+        <div className="inline-flex items-center gap-2 px-3 py-1.5 bg-[var(--color-bg-subtle)] rounded-full">
+          <div className={`w-2 h-2 rounded-full ${
+            phase === 'playing1' ? 'bg-[var(--color-primary)] animate-pulse' : 'bg-[var(--color-text-muted)]'
+          }`} />
+          <span className="text-sm text-[var(--color-text-muted)]">{clipLabel || 'Ready'}</span>
+          <div className={`w-2 h-2 rounded-full ${
+            phase === 'playing2' ? 'bg-[var(--color-primary)] animate-pulse' : 'bg-[var(--color-text-muted)]'
+          }`} />
+        </div>
+      </div>
+
+      <p className="text-center text-lg font-medium mb-8">Same species or different?</p>
+
+      <div className="flex gap-4 justify-center mb-6">
+        <button
+          onClick={() => handleAnswer(true)}
+          disabled={phase !== 'answering' && !answered}
+          className={`flex-1 max-w-[180px] py-6 rounded-2xl border-2 text-lg font-bold transition-all ${
+            answered && selected === true
+              ? item.isSame
+                ? 'bg-[var(--color-success-light)] border-[var(--color-success)] text-[var(--color-success)]'
+                : 'bg-[var(--color-error-light)] border-[var(--color-error)] text-[var(--color-error)]'
+              : 'bg-white border-[var(--color-bg-subtle)] hover:border-[var(--color-primary)] active:scale-[0.98]'
+          } ${phase !== 'answering' && !answered ? 'opacity-50' : ''}`}
+        >
+          Same
+        </button>
+        <button
+          onClick={() => handleAnswer(false)}
+          disabled={phase !== 'answering' && !answered}
+          className={`flex-1 max-w-[180px] py-6 rounded-2xl border-2 text-lg font-bold transition-all ${
+            answered && selected === false
+              ? !item.isSame
+                ? 'bg-[var(--color-success-light)] border-[var(--color-success)] text-[var(--color-success)]'
+                : 'bg-[var(--color-error-light)] border-[var(--color-error)] text-[var(--color-error)]'
+              : 'bg-white border-[var(--color-bg-subtle)] hover:border-[var(--color-primary)] active:scale-[0.98]'
+          } ${phase !== 'answering' && !answered ? 'opacity-50' : ''}`}
+        >
+          Different
+        </button>
+      </div>
+
+      {answered && secondSpecies && (
+        <div className="mt-auto p-4 bg-[var(--color-bg)] rounded-xl">
+          <div className="flex gap-4">
+            <div className="flex-1 text-center">
+              {item.targetSpecies.photo?.url && (
+                <img
+                  src={item.targetSpecies.photo.url}
+                  alt={item.targetSpecies.common_name}
+                  className="w-16 h-16 rounded-lg object-cover mx-auto mb-1"
+                />
+              )}
+              <p className="text-xs font-medium">{item.targetSpecies.common_name}</p>
+            </div>
+            <div className="flex-1 text-center">
+              {secondSpecies.photo?.url && (
+                <img
+                  src={secondSpecies.photo.url}
+                  alt={secondSpecies.common_name}
+                  className="w-16 h-16 rounded-lg object-cover mx-auto mb-1"
+                />
+              )}
+              <p className="text-xs font-medium">{secondSpecies.common_name}</p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/birdsong/src/components/quiz/ThreeChoiceQuiz.tsx
+++ b/birdsong/src/components/quiz/ThreeChoiceQuiz.tsx
@@ -1,0 +1,79 @@
+import { useState, useRef, useMemo } from 'react';
+import type { QuizItem } from '../../core/types';
+import { AudioButton } from '../shared/AudioButton';
+
+export function ThreeChoiceQuiz({
+  item,
+  onAnswer,
+}: {
+  item: QuizItem;
+  onAnswer: (correct: boolean, responseTimeMs: number) => void;
+}) {
+  const [selected, setSelected] = useState<string | null>(null);
+  const [answered, setAnswered] = useState(false);
+  const startTimeRef = useRef(Date.now());
+
+  const choices = useMemo(
+    () => [item.targetSpecies, ...item.distractors].sort(() => Math.random() - 0.5),
+    [item.targetSpecies, item.distractors]
+  );
+
+  const handleSelect = (speciesId: string) => {
+    if (answered) return;
+    const responseTime = Date.now() - startTimeRef.current;
+    const correct = speciesId === item.targetSpecies.id;
+    setSelected(speciesId);
+    setAnswered(true);
+    onAnswer(correct, responseTime);
+  };
+
+  return (
+    <div className="flex flex-col h-full p-4 pb-20">
+      <div className="text-center mb-4">
+        <AudioButton clips={[item.clip]} label="Play Sound" autoPlay />
+      </div>
+
+      <p className="text-center text-lg font-medium mb-4">Which bird is this?</p>
+
+      <div className="flex flex-col gap-3 flex-1">
+        {choices.map((sp) => {
+          let bgClass = 'bg-white border-[var(--color-bg-subtle)]';
+          if (answered) {
+            if (sp.id === item.targetSpecies.id) {
+              bgClass = 'bg-[var(--color-success-light)] border-[var(--color-success)]';
+            } else if (sp.id === selected) {
+              bgClass = 'bg-[var(--color-error-light)] border-[var(--color-error)]';
+            }
+          }
+
+          return (
+            <button
+              key={sp.id}
+              onClick={() => handleSelect(sp.id)}
+              disabled={answered}
+              className={`flex items-center gap-3 p-3 rounded-xl border-2 transition-all ${bgClass} ${
+                !answered ? 'hover:border-[var(--color-primary)] active:scale-[0.98]' : ''
+              }`}
+            >
+              {sp.photo?.url && (
+                <img
+                  src={sp.photo.url}
+                  alt={sp.common_name}
+                  className="w-12 h-12 rounded-lg object-cover"
+                />
+              )}
+              <div className="text-left">
+                <p className="font-medium text-sm">{sp.common_name}</p>
+                {answered && sp.id === item.targetSpecies.id && (
+                  <p className="text-xs text-[var(--color-success)] italic mt-0.5">
+                    "{item.targetSpecies.mnemonic}"
+                  </p>
+                )}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/birdsong/src/components/shared/AttributionInfo.tsx
+++ b/birdsong/src/components/shared/AttributionInfo.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import type { Photo } from '../../core/types';
+
+export function AttributionInfo({ photo }: { photo: Photo }) {
+  const [show, setShow] = useState(false);
+
+  return (
+    <div className="relative inline-block">
+      <button
+        onClick={() => setShow(!show)}
+        className="text-[var(--color-text-muted)] text-sm hover:text-[var(--color-text)]"
+        title="Photo attribution"
+      >
+        (i)
+      </button>
+      {show && (
+        <div className="absolute top-full right-0 mt-1 bg-white shadow-lg rounded-lg p-3 text-xs text-[var(--color-text-muted)] z-50 w-56 border border-[var(--color-bg-subtle)]">
+          <p>Photo: {photo.source}</p>
+          <p className="mt-1">{photo.license}</p>
+          <p className="mt-1">
+            <a href={photo.wikipedia_page} target="_blank" rel="noopener noreferrer" className="text-[var(--color-secondary)] underline">
+              Wikipedia
+            </a>
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/birdsong/src/components/shared/AudioButton.tsx
+++ b/birdsong/src/components/shared/AudioButton.tsx
@@ -1,0 +1,110 @@
+import { useState, useRef, useEffect } from 'react';
+import type { AudioClip } from '../../core/types';
+import { useAppStore } from '../../store/appStore';
+import { getRecordistAttribution } from '../../core/manifest';
+
+export function AudioButton({
+  clips,
+  label,
+  autoPlay = false,
+}: {
+  clips: AudioClip[];
+  label: string;
+  autoPlay?: boolean;
+}) {
+  const audioPlayer = useAppStore((s) => s.audioPlayer);
+  const setLastPlayedClip = useAppStore((s) => s.setLastPlayedClip);
+  const [clipIndex, setClipIndex] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [showAttrib, setShowAttrib] = useState(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  useEffect(() => {
+    audioPlayer.onStateChange = (isPlaying) => {
+      if (mountedRef.current) setPlaying(isPlaying);
+    };
+  }, [audioPlayer]);
+
+  useEffect(() => {
+    if (autoPlay && clips.length > 0) {
+      handlePlay();
+    }
+  }, [autoPlay]);
+
+  const handlePlay = async () => {
+    if (clips.length === 0) return;
+    const clip = clips[clipIndex];
+    setLoading(true);
+    setPlaying(false);
+    try {
+      await audioPlayer.play(clip.audio_url);
+      setLastPlayedClip(clip.xc_id.split('_')[0], clip.xc_id);
+    } finally {
+      if (mountedRef.current) setLoading(false);
+    }
+  };
+
+  const handleStop = () => {
+    audioPlayer.stop();
+  };
+
+  const handleClick = () => {
+    if (playing) {
+      handleStop();
+    } else {
+      const nextIndex = playing ? (clipIndex + 1) % clips.length : clipIndex;
+      setClipIndex(nextIndex);
+      handlePlay();
+    }
+  };
+
+  const currentClip = clips[clipIndex];
+
+  return (
+    <div className="relative">
+      <button
+        onClick={handleClick}
+        disabled={clips.length === 0}
+        className="flex items-center gap-2 px-4 py-2 rounded-lg bg-[var(--color-primary)] text-white font-medium hover:bg-[var(--color-primary-dark)] transition-colors disabled:opacity-50"
+      >
+        {loading ? (
+          <span className="w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+        ) : playing ? (
+          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+            <rect x="6" y="4" width="4" height="16" />
+            <rect x="14" y="4" width="4" height="16" />
+          </svg>
+        ) : (
+          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        )}
+        <span>{label}</span>
+        {clips.length > 1 && (
+          <span className="text-xs opacity-75">({clipIndex + 1}/{clips.length})</span>
+        )}
+      </button>
+      {currentClip && (
+        <button
+          onClick={(e) => { e.stopPropagation(); setShowAttrib(!showAttrib); }}
+          className="ml-2 text-[var(--color-text-muted)] text-sm hover:text-[var(--color-text)]"
+          title="Attribution"
+        >
+          (i)
+        </button>
+      )}
+      {showAttrib && currentClip && (
+        <div className="absolute top-full left-0 mt-1 bg-white shadow-lg rounded-lg p-3 text-xs text-[var(--color-text-muted)] z-50 w-64 border border-[var(--color-bg-subtle)]">
+          <p>{getRecordistAttribution(currentClip)}</p>
+          <p className="mt-1">{currentClip.location}</p>
+          <p className="mt-1"><a href={currentClip.license} target="_blank" rel="noopener noreferrer" className="text-[var(--color-secondary)] underline">License</a></p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/birdsong/src/components/shared/Navigation.tsx
+++ b/birdsong/src/components/shared/Navigation.tsx
@@ -1,0 +1,34 @@
+import { useAppStore } from '../../store/appStore';
+
+const tabs = [
+  { id: 'learn' as const, label: 'Learn', icon: '📖' },
+  { id: 'quiz' as const, label: 'Quiz', icon: '🎯' },
+  { id: 'progress' as const, label: 'Progress', icon: '📊' },
+] as const;
+
+export function Navigation() {
+  const activeTab = useAppStore((s) => s.activeTab);
+  const setTab = useAppStore((s) => s.setTab);
+
+  return (
+    <>
+      <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-[var(--color-bg-subtle)] flex justify-around items-center h-16 z-50"
+           style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}>
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setTab(tab.id)}
+            className={`flex flex-col items-center justify-center flex-1 py-2 transition-colors ${
+              activeTab === tab.id
+                ? 'text-[var(--color-primary)]'
+                : 'text-[var(--color-text-muted)]'
+            }`}
+          >
+            <span className="text-xl">{tab.icon}</span>
+            <span className="text-xs mt-0.5 font-medium">{tab.label}</span>
+          </button>
+        ))}
+      </nav>
+    </>
+  );
+}

--- a/birdsong/src/core/fsrs.ts
+++ b/birdsong/src/core/fsrs.ts
@@ -1,0 +1,110 @@
+import { fsrs, createEmptyCard, Rating, State, type Card, type Grade } from 'ts-fsrs';
+import type { UserProgress } from './types';
+
+const scheduler = fsrs({
+  request_retention: 0.85,
+  maximum_interval: 180,
+  w: [
+    0.3, 0.6, 1.8, 4.5,
+    5.0, 1.0, 0.75, 0.0, 1.5, 0.1,
+    1.0, 2.0, 0.05, 0.3, 1.4, 0.2, 2.8,
+  ],
+  enable_fuzz: false,
+  enable_short_term: false,
+  learning_steps: [],
+  relearning_steps: [],
+});
+
+function stateToString(state: State): UserProgress['state'] {
+  switch (state) {
+    case State.New: return 'new';
+    case State.Learning: return 'learning';
+    case State.Review: return 'review';
+    case State.Relearning: return 'relearning';
+  }
+}
+
+export function createNewProgress(speciesId: string): UserProgress {
+  const card = createEmptyCard();
+  return {
+    speciesId,
+    introduced: false,
+    stability: card.stability,
+    difficulty: card.difficulty,
+    elapsedDays: card.elapsed_days,
+    scheduledDays: card.scheduled_days,
+    reps: card.reps,
+    lapses: card.lapses,
+    state: 'new',
+  };
+}
+
+function progressToCard(progress: UserProgress): Card {
+  let state: State;
+  switch (progress.state) {
+    case 'new': state = State.New; break;
+    case 'learning': state = State.Learning; break;
+    case 'review': state = State.Review; break;
+    case 'relearning': state = State.Relearning; break;
+  }
+  return {
+    due: progress.nextReview ? new Date(progress.nextReview) : new Date(),
+    stability: progress.stability,
+    difficulty: progress.difficulty,
+    elapsed_days: progress.elapsedDays,
+    scheduled_days: progress.scheduledDays,
+    learning_steps: 0,
+    reps: progress.reps,
+    lapses: progress.lapses,
+    state,
+    last_review: progress.lastReview ? new Date(progress.lastReview) : undefined,
+  };
+}
+
+function cardToProgress(card: Card, speciesId: string, introduced: boolean): UserProgress {
+  return {
+    speciesId,
+    introduced,
+    stability: card.stability,
+    difficulty: card.difficulty,
+    elapsedDays: card.elapsed_days,
+    scheduledDays: card.scheduled_days,
+    reps: card.reps,
+    lapses: card.lapses,
+    state: stateToString(card.state),
+    lastReview: card.last_review ? card.last_review.getTime() : undefined,
+    nextReview: card.due.getTime(),
+  };
+}
+
+export function scheduleReview(progress: UserProgress, rating: Grade): UserProgress {
+  const card = progressToCard(progress);
+  const now = new Date();
+  const result = scheduler.next(card, now, rating);
+  return cardToProgress(result.card, progress.speciesId, progress.introduced);
+}
+
+export function isDue(progress: UserProgress): boolean {
+  if (!progress.introduced) return false;
+  if (!progress.nextReview) return true;
+  return Date.now() >= progress.nextReview;
+}
+
+export function ratingFromOutcome(correct: boolean, responseTimeMs: number): Grade {
+  if (!correct) return Rating.Again;
+  if (responseTimeMs < 2500) return Rating.Easy;
+  if (responseTimeMs < 7000) return Rating.Good;
+  return Rating.Hard;
+}
+
+export function ratingFromOutcomeSameDifferent(correct: boolean, responseTimeMs: number): Grade {
+  if (!correct) return Rating.Again;
+  if (responseTimeMs < 4000) return Rating.Easy;
+  if (responseTimeMs < 10000) return Rating.Good;
+  return Rating.Hard;
+}
+
+export function getNextReviewDate(progress: UserProgress): Date | null {
+  if (!progress.nextReview) return null;
+  return new Date(progress.nextReview);
+}

--- a/birdsong/src/core/lesson.ts
+++ b/birdsong/src/core/lesson.ts
@@ -1,0 +1,121 @@
+import type { Lesson, UserProgress, Species, IntroQuizItem, ReviewQuizItem, AudioClip } from './types';
+import { getAllClips } from './manifest';
+
+export function getNextLesson(
+  lessons: Lesson[],
+  completedLessonNums: number[]
+): Lesson | null {
+  const completedSet = new Set(completedLessonNums);
+  const next = lessons.find((l) => !completedSet.has(l.lesson));
+  return next ?? null;
+}
+
+export function isLessonAvailable(
+  lessonNum: number,
+  completedLessonNums: number[],
+  allProgress: Map<string, UserProgress>
+): boolean {
+  if (lessonNum === 1) return true;
+  const prevComplete = completedLessonNums.includes(lessonNum - 1);
+  if (!prevComplete) return false;
+  for (const p of allProgress.values()) {
+    if (p.state === 'relearning') return false;
+  }
+  return true;
+}
+
+export function isLessonComplete(
+  lesson: Lesson,
+  allProgress: Map<string, UserProgress>
+): boolean {
+  return lesson.species.every((id) => {
+    const p = allProgress.get(id);
+    return p?.introduced === true;
+  });
+}
+
+function pickRandom<T>(arr: T[], count: number, exclude?: Set<T>): T[] {
+  const available = exclude ? arr.filter((x) => !exclude.has(x)) : [...arr];
+  const shuffled = available.sort(() => Math.random() - 0.5);
+  return shuffled.slice(0, count);
+}
+
+function selectRandomClip(clips: AudioClip[], lastClipId?: string): AudioClip {
+  const available = clips.length > 1 && lastClipId
+    ? clips.filter((c) => c.xc_id !== lastClipId)
+    : clips;
+  return available[Math.floor(Math.random() * available.length)];
+}
+
+export function buildIntroQuiz(
+  lesson: Lesson,
+  introducedSpecies: Species[],
+  allSpecies: Species[],
+  lastPlayedClipIds: Map<string, string>
+): IntroQuizItem[] {
+  const lessonSpecies = lesson.species
+    .map((id) => allSpecies.find((s) => s.id === id))
+    .filter((s): s is Species => s !== undefined);
+
+  const items: IntroQuizItem[] = [];
+  const lessonIds = new Set(lesson.species);
+
+  for (const sp of lessonSpecies) {
+    const allClips = getAllClips(sp);
+    const clip = selectRandomClip(allClips, lastPlayedClipIds.get(sp.id));
+    const distractorPool = introducedSpecies.length > 0
+      ? introducedSpecies.filter((s) => !lessonIds.has(s.id))
+      : lessonSpecies.filter((s) => s.id !== sp.id);
+    const distractors = pickRandom(distractorPool, 2, new Set([sp]));
+    items.push({ targetSpecies: sp, distractors, clip });
+  }
+
+  if (introducedSpecies.length > 0) {
+    const reviewPool = introducedSpecies.slice();
+    const reviews = pickRandom(reviewPool, 2);
+    for (const sp of reviews) {
+      const allClips = getAllClips(sp);
+      const clip = selectRandomClip(allClips, lastPlayedClipIds.get(sp.id));
+      const distractorPool = [...introducedSpecies, ...lessonSpecies].filter(
+        (s) => s.id !== sp.id
+      );
+      const distractors = pickRandom(distractorPool, 2, new Set([sp]));
+      items.push({ targetSpecies: sp, distractors, clip });
+    }
+  }
+
+  return items.sort(() => Math.random() - 0.5);
+}
+
+export function buildReviewQuiz(
+  introducedSpecies: Species[],
+  lastPlayedClipIds: Map<string, string>
+): ReviewQuizItem[] {
+  if (introducedSpecies.length < 3) return [];
+  const count = Math.min(3, introducedSpecies.length);
+  const selected = pickRandom(introducedSpecies, count);
+  return selected.map((sp) => {
+    const allClips = getAllClips(sp);
+    const clip = selectRandomClip(allClips, lastPlayedClipIds.get(sp.id));
+    const distractorPool = introducedSpecies.filter((s) => s.id !== sp.id);
+    const distractors = pickRandom(distractorPool, 2, new Set([sp]));
+    return { targetSpecies: sp, distractors, clip };
+  });
+}
+
+export function getCompletedLessonNums(
+  lessons: Lesson[],
+  allProgress: Map<string, UserProgress>
+): number[] {
+  return lessons
+    .filter((l) => isLessonComplete(l, allProgress))
+    .map((l) => l.lesson);
+}
+
+export function getAvailableLessons(
+  lessons: Lesson[],
+  allProgress: Map<string, UserProgress>
+): Lesson[] {
+  const completed = getCompletedLessonNums(lessons, allProgress);
+  return lessons.filter((l) => isLessonAvailable(l.lesson, completed, allProgress));
+}

--- a/birdsong/src/core/manifest.ts
+++ b/birdsong/src/core/manifest.ts
@@ -1,0 +1,36 @@
+import type { Manifest, Species, ConfuserPair, Lesson } from './types';
+
+export async function loadManifest(): Promise<Manifest> {
+  const resp = await fetch('/content/manifest.json');
+  if (!resp.ok) throw new Error(`Failed to load manifest: ${resp.status}`);
+  return resp.json();
+}
+
+export function getSpeciesById(manifest: Manifest, id: string): Species | undefined {
+  return manifest.species.find((s) => s.id === id);
+}
+
+export function getSpeciesByIds(manifest: Manifest, ids: string[]): Species[] {
+  return ids
+    .map((id) => manifest.species.find((s) => s.id === id))
+    .filter((s): s is Species => s !== undefined);
+}
+
+export function getInTierConfuserPairs(manifest: Manifest): ConfuserPair[] {
+  const tierIds = new Set(manifest.species.map((s) => s.id));
+  return manifest.confuser_pairs.filter(
+    (p) => tierIds.has(p.pair[0]) && tierIds.has(p.pair[1])
+  );
+}
+
+export function getLessons(manifest: Manifest): Lesson[] {
+  return manifest.lesson_plan.lessons;
+}
+
+export function getAllClips(species: Species): import('./types').AudioClip[] {
+  return [...species.audio_clips.songs, ...species.audio_clips.calls];
+}
+
+export function getRecordistAttribution(clip: import('./types').AudioClip): string {
+  return `Recording by ${clip.recordist}, Xeno-canto ${clip.xc_id}`;
+}

--- a/birdsong/src/core/quiz.ts
+++ b/birdsong/src/core/quiz.ts
@@ -1,0 +1,187 @@
+import type { UserProgress, QuizItem, Species, ConfuserPair, AudioClip, ExerciseType } from './types';
+import { getAllClips } from './manifest';
+
+function selectDistractors(
+  target: Species,
+  introduced: Species[],
+  confuserPairs: ConfuserPair[],
+  count: number
+): Species[] {
+  const confuserIds = new Set<string>();
+  for (const pair of confuserPairs) {
+    if (pair.pair[0] === target.id) confuserIds.add(pair.pair[1]);
+    if (pair.pair[1] === target.id) confuserIds.add(pair.pair[0]);
+  }
+
+  const confuserSpecies = introduced.filter(
+    (s) => confuserIds.has(s.id) && s.id !== target.id
+  );
+  const otherSpecies = introduced.filter(
+    (s) => !confuserIds.has(s.id) && s.id !== target.id
+  );
+
+  const shuffledConfusers = confuserSpecies.sort(() => Math.random() - 0.5);
+  const shuffledOthers = otherSpecies.sort(() => Math.random() - 0.5);
+
+  const distractors: Species[] = [];
+  for (const s of shuffledConfusers) {
+    if (distractors.length >= count) break;
+    distractors.push(s);
+  }
+  for (const s of shuffledOthers) {
+    if (distractors.length >= count) break;
+    distractors.push(s);
+  }
+
+  return distractors.slice(0, count);
+}
+
+function selectClip(species: Species, lastPlayedClipId?: string): AudioClip {
+  const clips = getAllClips(species);
+  if (clips.length <= 1) return clips[0];
+  const available = lastPlayedClipId
+    ? clips.filter((c) => c.xc_id !== lastPlayedClipId)
+    : clips;
+  return available[Math.floor(Math.random() * available.length)] ?? clips[0];
+}
+
+function selectExerciseType(progress: UserProgress): ExerciseType {
+  if (progress.reps < 3) return 'three_choice';
+  return 'same_different';
+}
+
+export function buildQuizSession(
+  allProgress: Map<string, UserProgress>,
+  species: Species[],
+  confuserPairs: ConfuserPair[],
+  lastPlayedClipIds: Map<string, string>,
+  targetCount: number = 9
+): QuizItem[] {
+  const introduced: Species[] = [];
+  const due: Species[] = [];
+
+  for (const sp of species) {
+    const p = allProgress.get(sp.id);
+    if (!p?.introduced) continue;
+    introduced.push(sp);
+    if (isDueForReview(p)) due.push(sp);
+  }
+
+  const items: QuizItem[] = [];
+  const dueSorted = due.sort((a, b) => {
+    const pa = allProgress.get(a.id)!;
+    const pb = allProgress.get(b.id)!;
+    const overdueA = (pa.nextReview ?? Infinity) - Date.now();
+    const overdueB = (pb.nextReview ?? Infinity) - Date.now();
+    return overdueA - overdueB;
+  });
+
+  const reviewCount = Math.min(
+    Math.round(targetCount * 0.7),
+    dueSorted.length
+  );
+
+  for (let i = 0; i < reviewCount; i++) {
+    const sp = dueSorted[i];
+    const progress = allProgress.get(sp.id)!;
+    const exerciseType = selectExerciseType(progress);
+    const clip = selectClip(sp, lastPlayedClipIds.get(sp.id));
+    const distractors = selectDistractors(sp, introduced, confuserPairs, 2);
+
+    if (exerciseType === 'same_different' && introduced.length >= 2) {
+      const samePair = Math.random() < 0.5;
+      if (samePair) {
+        const allClips = getAllClips(sp);
+        const secondClip = allClips.filter((c) => c.xc_id !== clip.xc_id);
+        items.push({
+          targetSpecies: sp,
+          exerciseType: 'same_different',
+          distractors: [],
+          clip,
+          secondClip: secondClip[0] ?? clip,
+          isSame: true,
+        });
+      } else {
+        const confuserForPair = confuserPairs.find(
+          (p) => (p.pair[0] === sp.id || p.pair[1] === sp.id)
+        );
+        let otherSp: Species | undefined;
+        if (confuserForPair) {
+          const otherId = confuserForPair.pair[0] === sp.id
+            ? confuserForPair.pair[1]
+            : confuserForPair.pair[0];
+          otherSp = introduced.find((s) => s.id === otherId);
+        }
+        if (!otherSp) {
+          const others = introduced.filter((s) => s.id !== sp.id);
+          otherSp = others[Math.floor(Math.random() * others.length)];
+        }
+        const otherClip = selectClip(otherSp, lastPlayedClipIds.get(otherSp.id));
+        items.push({
+          targetSpecies: sp,
+          exerciseType: 'same_different',
+          distractors: [],
+          clip,
+          secondClip: otherClip,
+          isSame: false,
+        });
+      }
+    } else {
+      items.push({
+        targetSpecies: sp,
+        exerciseType: 'three_choice',
+        distractors,
+        clip,
+      });
+    }
+  }
+
+  while (items.length < targetCount && dueSorted.length > items.length) {
+    const remaining = dueSorted.filter(
+      (sp) => !items.some((it) => it.targetSpecies.id === sp.id)
+    );
+    if (remaining.length === 0) break;
+    const sp = remaining[0];
+    const clip = selectClip(sp, lastPlayedClipIds.get(sp.id));
+    const distractors = selectDistractors(sp, introduced, confuserPairs, 2);
+    items.push({
+      targetSpecies: sp,
+      exerciseType: 'three_choice',
+      distractors,
+      clip,
+    });
+  }
+
+  return items.sort(() => Math.random() - 0.5);
+}
+
+function isDueForReview(progress: UserProgress): boolean {
+  if (!progress.introduced) return false;
+  if (!progress.nextReview) return true;
+  return Date.now() >= progress.nextReview;
+}
+
+export function countDue(allProgress: Map<string, UserProgress>): number {
+  let count = 0;
+  for (const p of allProgress.values()) {
+    if (isDueForReview(p)) count++;
+  }
+  return count;
+}
+
+export function getDueSpecies(
+  allProgress: Map<string, UserProgress>,
+  species: Species[]
+): Species[] {
+  return species.filter((sp) => {
+    const p = allProgress.get(sp.id);
+    return p ? isDueForReview(p) : false;
+  });
+}
+
+export function hasRelearning(allProgress: Map<string, UserProgress>): boolean {
+  for (const p of allProgress.values()) {
+    if (p.state === 'relearning') return true;
+  }
+  return false;
+}

--- a/birdsong/src/core/types.ts
+++ b/birdsong/src/core/types.ts
@@ -1,0 +1,141 @@
+export interface Species {
+  id: string;
+  common_name: string;
+  scientific_name: string;
+  family: string;
+  ebird_frequency_pct: number;
+  habitat: string[];
+  seasonality: string;
+  mnemonic: string;
+  sound_types: {
+    song: string;
+    call: string;
+  };
+  confuser_species: string[];
+  confuser_notes: string;
+  audio_clips: {
+    songs: AudioClip[];
+    calls: AudioClip[];
+  };
+  photo: Photo;
+  wikipedia_audio?: WikipediaAudio[];
+}
+
+export interface AudioClip {
+  xc_id: string;
+  xc_url: string;
+  audio_url: string;
+  type: string;
+  quality: string;
+  length: string;
+  recordist: string;
+  license: string;
+  location: string;
+  country: string;
+  score: number;
+}
+
+export interface Photo {
+  url: string;
+  width?: number;
+  height?: number;
+  filename: string;
+  source: string;
+  license: string;
+  wikipedia_page: string;
+}
+
+export interface WikipediaAudio {
+  url: string;
+  filename: string;
+  source: string;
+  license: string;
+  commons_page: string;
+}
+
+export interface UserProgress {
+  speciesId: string;
+  introduced: boolean;
+  introducedAt?: number;
+  stability: number;
+  difficulty: number;
+  elapsedDays: number;
+  scheduledDays: number;
+  reps: number;
+  lapses: number;
+  state: 'new' | 'learning' | 'review' | 'relearning';
+  lastReview?: number;
+  nextReview?: number;
+}
+
+export interface ConfuserPair {
+  pair: [string, string];
+  label: string;
+  difficulty: 'easy' | 'medium' | 'hard';
+  key_difference: string;
+}
+
+export interface Lesson {
+  lesson: number;
+  title: string;
+  species: string[];
+  rationale: string;
+}
+
+export type ExerciseType =
+  | 'three_choice'
+  | 'same_different';
+
+export type Tab = 'learn' | 'quiz' | 'progress' | 'credits';
+
+export interface Manifest {
+  version: string;
+  tier: number;
+  region: string;
+  target_species_count: number;
+  species: Species[];
+  confuser_pairs: ConfuserPair[];
+  lesson_plan: {
+    description: string;
+    lessons: Lesson[];
+  };
+}
+
+export interface ConfusionEvent {
+  targetId: string;
+  chosenId: string;
+  timestamp: number;
+}
+
+export type LessonPhase = 'review' | 'cards' | 'quiz' | 'complete';
+
+export interface IntroQuizItem {
+  targetSpecies: Species;
+  distractors: Species[];
+  clip: AudioClip;
+}
+
+export interface ReviewQuizItem {
+  targetSpecies: Species;
+  distractors: Species[];
+  clip: AudioClip;
+}
+
+export interface QuizItem {
+  targetSpecies: Species;
+  exerciseType: ExerciseType;
+  distractors: Species[];
+  clip: AudioClip;
+  secondClip?: AudioClip;
+  isSame?: boolean;
+}
+
+export interface LessonSession {
+  lesson: Lesson;
+  phase: LessonPhase;
+  cardIndex: number;
+  introQuizItems: IntroQuizItem[];
+  reviewQuizItems: ReviewQuizItem[];
+  quizIndex: number;
+  quizResults: boolean[];
+}

--- a/birdsong/src/index.css
+++ b/birdsong/src/index.css
@@ -1,0 +1,50 @@
+@import "tailwindcss";
+
+@theme {
+  --color-primary: #8B6F47;
+  --color-primary-light: #A68860;
+  --color-primary-dark: #6B5535;
+  --color-secondary: #5B8A72;
+  --color-secondary-light: #7AA894;
+  --color-secondary-dark: #3E6B54;
+  --color-bg: #FAF8F5;
+  --color-bg-subtle: #F0EDE8;
+  --color-text: #1A1A1A;
+  --color-text-muted: #6B6B6B;
+  --color-success: #4CAF50;
+  --color-success-light: #E8F5E9;
+  --color-error: #E53935;
+  --color-error-light: #FFEBEE;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body, #root {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-tap-highlight-color: transparent;
+}
+
+#root {
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+@keyframes pulse-subtle {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+.animate-pulse-subtle {
+  animation: pulse-subtle 2s ease-in-out infinite;
+}

--- a/birdsong/src/main.tsx
+++ b/birdsong/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/birdsong/src/store/appStore.ts
+++ b/birdsong/src/store/appStore.ts
@@ -1,0 +1,121 @@
+import { create } from 'zustand';
+import type { Manifest, Species, UserProgress, Tab, LessonSession } from '../core/types';
+import { loadManifest } from '../core/manifest';
+import { DexieStorage, type StorageAdapter } from '../adapters/storage';
+import { WebAudioPlayer, type AudioPlayer } from '../adapters/audio';
+import { createNewProgress } from '../core/fsrs';
+
+interface AppState {
+  initialized: boolean;
+  error: string | null;
+  activeTab: Tab;
+  manifest: Manifest | null;
+  allProgress: Map<string, UserProgress>;
+  lastPlayedClipId: Map<string, string>;
+  audioPlayer: AudioPlayer;
+  storage: StorageAdapter;
+  activeLessonSession: LessonSession | null;
+
+  initializedSpecies: () => Species[];
+  completedLessonNums: () => number[];
+
+  initialize: () => Promise<void>;
+  setTab: (tab: Tab) => void;
+  updateProgress: (speciesId: string, progress: UserProgress) => Promise<void>;
+  introduceSpecies: (speciesIds: string[]) => Promise<void>;
+  logConfusion: (targetId: string, chosenId: string) => Promise<void>;
+  setActiveLessonSession: (session: LessonSession | null) => void;
+  setLastPlayedClip: (speciesId: string, clipId: string) => void;
+  getOrCreateProgress: (speciesId: string) => UserProgress;
+}
+
+export const useAppStore = create<AppState>((set, get) => ({
+  initialized: false,
+  error: null,
+  activeTab: 'learn',
+  manifest: null,
+  allProgress: new Map<string, UserProgress>(),
+  lastPlayedClipId: new Map<string, string>(),
+  audioPlayer: new WebAudioPlayer(),
+  storage: new DexieStorage(),
+  activeLessonSession: null,
+
+  initializedSpecies: () => {
+    const { manifest, allProgress } = get();
+    if (!manifest) return [];
+    return manifest.species.filter((sp) => allProgress.get(sp.id)?.introduced);
+  },
+
+  completedLessonNums: () => {
+    const { manifest, allProgress } = get();
+    if (!manifest) return [];
+    const lessons = manifest.lesson_plan.lessons;
+    return lessons
+      .filter((l) => l.species.every((id) => allProgress.get(id)?.introduced))
+      .map((l) => l.lesson);
+  },
+
+  initialize: async () => {
+    try {
+      const manifest = await loadManifest();
+      const allProgressArr = await get().storage.getAllProgress();
+      const allProgress = new Map<string, UserProgress>();
+      for (const p of allProgressArr) {
+        allProgress.set(p.speciesId, p);
+      }
+      set({ manifest, allProgress, initialized: true, error: null });
+    } catch {
+      set({ error: 'Failed to load bird data.', initialized: true });
+    }
+  },
+
+  setTab: (tab) => set({ activeTab: tab }),
+
+  updateProgress: async (speciesId, progress) => {
+    const { allProgress } = get();
+    const next = new Map(allProgress);
+    next.set(speciesId, progress);
+    set({ allProgress: next });
+    await get().storage.saveProgress(progress);
+  },
+
+  introduceSpecies: async (speciesIds) => {
+    const { allProgress, storage } = get();
+    const next = new Map(allProgress);
+    const now = Date.now();
+    for (const id of speciesIds) {
+      const existing = next.get(id);
+      if (existing && existing.introduced) continue;
+      const updated = existing
+        ? { ...existing, introduced: true, introducedAt: now }
+        : { ...createNewProgress(id), introduced: true, introducedAt: now };
+      next.set(id, updated);
+      await storage.saveProgress(updated);
+    }
+    set({ allProgress: next });
+  },
+
+  logConfusion: async (targetId, chosenId) => {
+    await get().storage.logConfusion({
+      targetId,
+      chosenId,
+      timestamp: Date.now(),
+    });
+  },
+
+  setActiveLessonSession: (session) => set({ activeLessonSession: session }),
+
+  setLastPlayedClip: (speciesId, clipId) => {
+    const { lastPlayedClipId } = get();
+    const next = new Map(lastPlayedClipId);
+    next.set(speciesId, clipId);
+    set({ lastPlayedClipId: next });
+  },
+
+  getOrCreateProgress: (speciesId) => {
+    const { allProgress } = get();
+    const existing = allProgress.get(speciesId);
+    if (existing) return existing;
+    return createNewProgress(speciesId);
+  },
+}));

--- a/birdsong/tsconfig.app.json
+++ b/birdsong/tsconfig.app.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "es2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "esnext",
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/birdsong/tsconfig.json
+++ b/birdsong/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/birdsong/tsconfig.node.json
+++ b/birdsong/tsconfig.node.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "es2023",
+    "lib": ["ES2023"],
+    "module": "esnext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/birdsong/vite.config.ts
+++ b/birdsong/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+})

--- a/download_media.py
+++ b/download_media.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Download and process bird audio clips and photos for the birdsong app.
+
+Usage:
+    uv run download_media.py
+"""
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "requests",
+#     "Pillow",
+# ]
+# ///
+
+import copy
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+import urllib.error
+import warnings
+
+from pathlib import Path
+from io import BytesIO
+
+import requests
+from PIL import Image
+
+warnings.filterwarnings("ignore", category=UserWarning, module="PIL")
+
+BASE_DIR = Path(__file__).resolve().parent
+INPUT_JSON = BASE_DIR / "tier1_seattle_birds_populated.json"
+OUTPUT_DIR = BASE_DIR / "birdsong" / "public" / "content"
+AUDIO_DIR = OUTPUT_DIR / "audio"
+PHOTO_DIR = OUTPUT_DIR / "photos"
+MANIFEST_PATH = OUTPUT_DIR / "manifest.json"
+
+USER_AGENT = "AvilingoBirdsongBot/1.0 (educational; https://github.com/avilingo)"
+FFMPEG_LOUDNORM = "loudnorm=I=-16:TP=-1.5:LRA=11"
+MAX_DURATION_S = 20
+TARGET_WIDTH_PX = 800
+XC_DELAY_S = 1.0
+
+
+def log(msg):
+    print(msg, flush=True)
+
+
+def warn(msg):
+    print(f"WARNING: {msg}", flush=True)
+
+
+def progress(done, total, label=""):
+    bar_len = 40
+    filled = int(bar_len * done / total) if total else 0
+    bar = "=" * filled + "-" * (bar_len - filled)
+    print(f"\r  [{bar}] {done}/{total} {label}", end="", flush=True)
+    if done == total:
+        print()
+
+
+def download_file(url, dest_path, headers=None, timeout=60):
+    if dest_path.exists():
+        return True
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest_path.parent / f"{dest_path.stem}_dl{dest_path.suffix}"
+    try:
+        req = requests.get(url, headers=headers or {}, timeout=timeout, stream=True)
+        req.raise_for_status()
+        with open(tmp, "wb") as f:
+            for chunk in req.iter_content(chunk_size=8192):
+                f.write(chunk)
+        if tmp.stat().st_size == 0:
+            warn(f"Downloaded empty file from {url}")
+            tmp.unlink()
+            return False
+        tmp.rename(dest_path)
+        return True
+    except Exception as e:
+        warn(f"Failed to download {url}: {e}")
+        if tmp.exists():
+            tmp.unlink()
+        return False
+
+
+def ffmpeg_normalize(input_path, output_path):
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = output_path.parent / f"{output_path.stem}_tmp{output_path.suffix}"
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(input_path),
+        "-af",
+        FFMPEG_LOUDNORM,
+        "-t",
+        str(MAX_DURATION_S),
+        "-c:a",
+        "libopus",
+        "-b:a",
+        "96k",
+        "-vn",
+        str(tmp),
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            last_lines = result.stderr.strip().split("\n")[-3:]
+            warn(f"ffmpeg failed for {input_path.name}: {'; '.join(last_lines)}")
+            if tmp.exists():
+                tmp.unlink()
+            return False
+        if not tmp.exists() or tmp.stat().st_size == 0:
+            warn(f"ffmpeg produced empty output for {input_path.name}")
+            return False
+        tmp.rename(output_path)
+        return True
+    except Exception as e:
+        warn(f"ffmpeg error for {input_path}: {e}")
+        if tmp.exists():
+            tmp.unlink()
+        return False
+
+
+def download_and_normalize_audio(url, dest_path, headers=None, is_xc=False):
+    if dest_path.exists():
+        return True
+    tmp_path = dest_path.parent / f"{dest_path.stem}_raw.mp3"
+    try:
+        if not download_file(url, tmp_path, headers=headers):
+            return False
+        ok = ffmpeg_normalize(tmp_path, dest_path)
+        return ok
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def download_and_resize_photo(url, dest_path):
+    if dest_path.exists():
+        return True
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        resp = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=60)
+        resp.raise_for_status()
+        img = Image.open(BytesIO(resp.content))
+        img = img.convert("RGB")
+        w, h = img.size
+        if w > TARGET_WIDTH_PX:
+            ratio = TARGET_WIDTH_PX / w
+            new_h = int(h * ratio)
+            img = img.resize((TARGET_WIDTH_PX, new_h), Image.LANCZOS)
+        tmp = dest_path.parent / f"{dest_path.stem}_tmp{dest_path.suffix}"
+        img.save(tmp, "JPEG", quality=85)
+        tmp.rename(dest_path)
+        return True
+    except Exception as e:
+        warn(f"Failed to download/resize photo {url}: {e}")
+        return False
+
+
+def main():
+    log(f"Reading {INPUT_JSON}")
+    with open(INPUT_JSON) as f:
+        data = json.load(f)
+
+    species_list = data["species"]
+    total_species = len(species_list)
+
+    xc_total = sum(
+        len(s["audio_clips"]["songs"]) + len(s["audio_clips"]["calls"])
+        for s in species_list
+    )
+    wp_total = sum(len(s.get("wikipedia_audio", [])) for s in species_list)
+    photo_total = sum(1 for s in species_list if s.get("photo", {}).get("url"))
+    log(
+        f"Found {total_species} species: {xc_total} XC clips, {wp_total} WP audio, {photo_total} photos"
+    )
+
+    xc_done = 0
+    wp_done = 0
+    photo_done = 0
+    xc_ok = 0
+    wp_ok = 0
+    photo_ok = 0
+
+    session = requests.Session()
+    session.headers.update({"User-Agent": USER_AGENT})
+
+    log("\n--- Downloading Xeno-canto audio clips ---")
+    last_xc_time = 0.0
+    for sp in species_list:
+        species_id = sp["id"]
+        all_clips = list(sp["audio_clips"]["songs"]) + list(sp["audio_clips"]["calls"])
+        for clip in all_clips:
+            xc_done += 1
+            xc_id = clip["xc_id"]
+            dest = AUDIO_DIR / species_id / f"{xc_id}.ogg"
+            if dest.exists():
+                xc_ok += 1
+                progress(xc_done, xc_total, f"XC {species_id}/{xc_id} (cached)")
+                continue
+            now = time.monotonic()
+            wait = XC_DELAY_S - (now - last_xc_time)
+            if wait > 0:
+                time.sleep(wait)
+            last_xc_time = time.monotonic()
+            ok = download_and_normalize_audio(
+                clip["audio_url"],
+                dest,
+                headers={
+                    "User-Agent": USER_AGENT,
+                    "Referer": "https://xeno-canto.org/",
+                },
+                is_xc=True,
+            )
+            if ok:
+                xc_ok += 1
+            progress(
+                xc_done, xc_total, f"XC {species_id}/{xc_id} {'OK' if ok else 'FAIL'}"
+            )
+
+    log(f"\nXC audio: {xc_ok}/{xc_total} downloaded successfully")
+
+    log("\n--- Downloading Wikipedia audio clips ---")
+    for sp in species_list:
+        species_id = sp["id"]
+        wp_clips = sp.get("wikipedia_audio", [])
+        for idx, clip in enumerate(wp_clips):
+            wp_done += 1
+            dest = AUDIO_DIR / species_id / f"wp_{idx}.ogg"
+            if dest.exists():
+                wp_ok += 1
+                progress(wp_done, wp_total, f"WP {species_id}/wp_{idx} (cached)")
+                continue
+            ok = download_and_normalize_audio(
+                clip["url"],
+                dest,
+                headers={"User-Agent": USER_AGENT},
+            )
+            if ok:
+                wp_ok += 1
+            progress(
+                wp_done, wp_total, f"WP {species_id}/wp_{idx} {'OK' if ok else 'FAIL'}"
+            )
+
+    log(f"\nWikipedia audio: {wp_ok}/{wp_total} downloaded successfully")
+
+    log("\n--- Downloading photos ---")
+    for sp in species_list:
+        species_id = sp["id"]
+        photo = sp.get("photo", {})
+        url = photo.get("url")
+        if not url:
+            continue
+        photo_done += 1
+        dest = PHOTO_DIR / f"{species_id}.jpg"
+        if dest.exists():
+            photo_ok += 1
+            progress(photo_done, photo_total, f"Photo {species_id} (cached)")
+            continue
+        ok = download_and_resize_photo(url, dest)
+        if ok:
+            photo_ok += 1
+        progress(
+            photo_done, photo_total, f"Photo {species_id} {'OK' if ok else 'FAIL'}"
+        )
+
+    log(f"\nPhotos: {photo_ok}/{photo_total} downloaded successfully")
+
+    log("\n--- Generating manifest.json ---")
+    manifest = copy.deepcopy(data)
+    for sp in manifest["species"]:
+        species_id = sp["id"]
+        for clip in sp["audio_clips"]["songs"]:
+            clip["audio_url"] = f"/content/audio/{species_id}/{clip['xc_id']}.ogg"
+        for clip in sp["audio_clips"]["calls"]:
+            clip["audio_url"] = f"/content/audio/{species_id}/{clip['xc_id']}.ogg"
+        if sp.get("photo", {}).get("url"):
+            sp["photo"]["url"] = f"/content/photos/{species_id}.jpg"
+        for idx, clip in enumerate(sp.get("wikipedia_audio", [])):
+            clip["url"] = f"/content/audio/{species_id}/wp_{idx}.ogg"
+
+    MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp_manifest = MANIFEST_PATH.parent / "manifest_tmp.json"
+    with open(tmp_manifest, "w") as f:
+        json.dump(manifest, f, indent=2)
+    tmp_manifest.rename(MANIFEST_PATH)
+    log(f"Wrote {MANIFEST_PATH}")
+
+    log("\n=== Summary ===")
+    log(f"  XC audio:   {xc_ok}/{xc_total}")
+    log(f"  WP audio:   {wp_ok}/{wp_total}")
+    log(f"  Photos:     {photo_ok}/{photo_total}")
+    total = xc_total + wp_total + photo_total
+    total_ok = xc_ok + wp_ok + photo_ok
+    log(f"  Total:      {total_ok}/{total}")
+    if total_ok < total:
+        log(
+            f"\n  {total - total_ok} downloads failed — re-run to retry (script is idempotent)"
+        )
+        sys.exit(1)
+    log("\nAll done!")
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,6 +1,0 @@
-def main():
-    print("Hello from avilingo-v2!")
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
## Summary
- Complete Birdsong web app implementation (Sprints 0-2): Learn mode with 5 progressive lessons, Quiz mode with FSRS-5 spaced repetition, Progress dashboard, and Credits page
- Media download pipeline (`download_media.py`) that downloads, normalizes (ffmpeg loudnorm + Opus), and generates a local manifest for all 75 XC audio clips, 18 Wikipedia audio clips, and 15 photos
- Clean architecture with pure TypeScript core modules (no React/DOM deps), platform adapters (Web Audio API, Dexie.js), and a single Zustand store

## What's Included
**Learn Mode**: Swipeable bird cards with photos/mnemonics/audio, 3-choice intro quizzes, forward testing review (Lesson 2+), lesson gating
**Quiz Mode**: FSRS-5 SRS with three-choice and same/different exercises, confusion logging, 8-10 item sessions, adaptive difficulty
**Infrastructure**: Media pipeline, Tailwind v4, React 19, TypeScript strict mode, mobile-first responsive design

## Known Follow-ups
- Replace swipe gestures with explicit Next/Previous buttons (finicky on some devices)
- Add rich media player with pause, skip-ahead, replay, and scrubbing controls