### PR TITLE
Add audio state coordination and spectrogram (Issues 1-4)

### DIFF
--- a/beakspeak/src/adapters/audio.test.ts
+++ b/beakspeak/src/adapters/audio.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { WebAudioPlayer } from './audio'
+
+// --- Web Audio API mocks ---
+
+function makeMockSource(): AudioBufferSourceNode {
+  const source = {
+    buffer: null as AudioBuffer | null,
+    connect: vi.fn().mockReturnThis(),
+    start: vi.fn(),
+    stop: vi.fn(),
+    onended: null as ((ev: Event) => void) | null,
+    disconnect: vi.fn(),
+  }
+  return source as unknown as AudioBufferSourceNode
+}
+
+function makeMockGainNode(): GainNode {
+  const gain = {
+    value: 1,
+    setValueAtTime: vi.fn().mockReturnThis(),
+    linearRampToValueAtTime: vi.fn().mockReturnThis(),
+  }
+  return { gain, connect: vi.fn(), disconnect: vi.fn() } as unknown as GainNode
+}
+
+function makeMockBuffer(duration = 10): AudioBuffer {
+  return {
+    duration,
+    length: duration * 44100,
+    sampleRate: 44100,
+    numberOfChannels: 1,
+    getChannelData: vi.fn(() => new Float32Array(duration * 44100)),
+    copyFromChannel: vi.fn(),
+    copyToChannel: vi.fn(),
+  } as unknown as AudioBuffer
+}
+
+function setupFetchMock() {
+  const arrayBuffer = new ArrayBuffer(8)
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    arrayBuffer: () => Promise.resolve(arrayBuffer),
+  }))
+}
+
+let mockSources: ReturnType<typeof makeMockSource>[]
+let mockGainNode: ReturnType<typeof makeMockGainNode>
+let mockBuffer: AudioBuffer
+
+function setupAudioContextMock() {
+  mockSources = []
+  mockGainNode = makeMockGainNode()
+  mockBuffer = makeMockBuffer()
+
+  const mockContext = {
+    state: 'running',
+    currentTime: 0,
+    destination: {},
+    resume: vi.fn().mockResolvedValue(undefined),
+    createBufferSource: vi.fn(() => {
+      const src = makeMockSource()
+      mockSources.push(src)
+      return src
+    }),
+    createGain: vi.fn(() => mockGainNode),
+    decodeAudioData: vi.fn().mockResolvedValue(mockBuffer),
+  }
+
+  vi.stubGlobal('AudioContext', class MockAudioContext {
+    state = mockContext.state
+    currentTime = mockContext.currentTime
+    destination = mockContext.destination
+    resume = mockContext.resume
+    createBufferSource = mockContext.createBufferSource
+    createGain = mockContext.createGain
+    decodeAudioData = mockContext.decodeAudioData
+  })
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  setupAudioContextMock()
+  setupFetchMock()
+})
+
+describe('WebAudioPlayer', () => {
+  describe('getActiveUrl', () => {
+    it('returns null when nothing has played', () => {
+      const player = new WebAudioPlayer()
+      expect(player.getActiveUrl()).toBeNull()
+    })
+
+    it('returns the URL after play()', async () => {
+      const player = new WebAudioPlayer()
+      await player.play('https://example.com/song.ogg')
+      expect(player.getActiveUrl()).toBe('https://example.com/song.ogg')
+    })
+
+    it('returns null after stop()', async () => {
+      const player = new WebAudioPlayer()
+      await player.play('https://example.com/song.ogg')
+      player.stop()
+      expect(player.getActiveUrl()).toBeNull()
+    })
+
+    it('returns the new URL when switching clips', async () => {
+      const player = new WebAudioPlayer()
+      await player.play('https://example.com/song.ogg')
+      await player.play('https://example.com/call.ogg')
+      expect(player.getActiveUrl()).toBe('https://example.com/call.ogg')
+      expect(player.getState()).toBe('playing')
+    })
+  })
+
+  describe('state transitions', () => {
+    it('transitions through idle → loading → playing during play()', async () => {
+      const player = new WebAudioPlayer()
+      const states: string[] = []
+      player.onStateChange(s => states.push(s))
+
+      await player.play('https://example.com/song.ogg')
+
+      expect(states).toEqual(['idle', 'loading', 'playing'])
+    })
+
+    it('transitions to idle on stop()', async () => {
+      const player = new WebAudioPlayer()
+      await player.play('https://example.com/song.ogg')
+
+      const states: string[] = []
+      player.onStateChange(s => states.push(s))
+      player.stop()
+
+      expect(states).toEqual(['idle'])
+      expect(player.getState()).toBe('idle')
+    })
+
+    it('clears activeUrl when clip ends naturally (onended)', async () => {
+      const player = new WebAudioPlayer()
+      await player.play('https://example.com/song.ogg')
+      expect(player.getActiveUrl()).toBe('https://example.com/song.ogg')
+
+      // Simulate the clip ending naturally
+      const source = mockSources[mockSources.length - 1]
+      source.onended!(new Event('ended'))
+
+      expect(player.getActiveUrl()).toBeNull()
+      expect(player.getState()).toBe('idle')
+    })
+  })
+
+  describe('getBuffer', () => {
+    it('returns null for a URL that has never been played', () => {
+      const player = new WebAudioPlayer()
+      expect(player.getBuffer('https://example.com/unknown.ogg')).toBeNull()
+    })
+
+    it('returns the cached AudioBuffer after play()', async () => {
+      const player = new WebAudioPlayer()
+      await player.play('https://example.com/song.ogg')
+      expect(player.getBuffer('https://example.com/song.ogg')).toBe(mockBuffer)
+    })
+  })
+
+  describe('getProgress', () => {
+    it('returns zeros when idle', () => {
+      const player = new WebAudioPlayer()
+      expect(player.getProgress()).toEqual({ currentTime: 0, duration: 0 })
+    })
+
+    it('reflects offset after play(url, offset)', async () => {
+      const player = new WebAudioPlayer()
+      await player.play('https://example.com/song.ogg', 5.0)
+      const progress = player.getProgress()
+      expect(progress.currentTime).toBeCloseTo(5.0, 1)
+      expect(progress.duration).toBe(mockBuffer.duration)
+
+      // Verify the offset was passed to source.start
+      const lastSource = mockSources[mockSources.length - 1]
+      expect(lastSource.start).toHaveBeenCalledWith(0, 5.0)
+    })
+
+    it('reports zero elapsed time at start of playback', async () => {
+      const player = new WebAudioPlayer()
+      await player.play('https://example.com/song.ogg')
+      expect(player.getProgress().currentTime).toBeCloseTo(0, 1)
+      expect(player.getProgress().duration).toBe(mockBuffer.duration)
+    })
+
+    it('returns zeros after stop()', async () => {
+      const player = new WebAudioPlayer()
+      await player.play('https://example.com/song.ogg', 3.0)
+      player.stop()
+      expect(player.getProgress()).toEqual({ currentTime: 0, duration: 0 })
+    })
+  })
+
+  describe('seek', () => {
+    it('is a no-op when stopped', () => {
+      const player = new WebAudioPlayer()
+      player.seek(10.0)
+      expect(player.getActiveUrl()).toBeNull()
+      expect(player.getState()).toBe('idle')
+      expect(player.getProgress()).toEqual({ currentTime: 0, duration: 0 })
+    })
+
+    it('restarts playback at the new offset while playing', async () => {
+      const player = new WebAudioPlayer()
+      await player.play('https://example.com/song.ogg')
+      expect(player.getActiveUrl()).toBe('https://example.com/song.ogg')
+
+      await player.seek(10.0)
+      expect(player.getActiveUrl()).toBe('https://example.com/song.ogg')
+      expect(player.getState()).toBe('playing')
+      expect(player.getProgress().currentTime).toBeCloseTo(10.0, 1)
+      expect(player.getProgress().duration).toBe(mockBuffer.duration)
+    })
+
+    it('passes the offset to source.start()', async () => {
+      const player = new WebAudioPlayer()
+      await player.play('https://example.com/song.ogg')
+      const countBefore = mockSources.length
+
+      await player.seek(7.5)
+
+      // A new source should have been created for the seek
+      expect(mockSources.length).toBe(countBefore + 1)
+      const lastSource = mockSources[mockSources.length - 1]
+      expect(lastSource.start).toHaveBeenCalledWith(0, 7.5)
+    })
+  })
+
+  describe('onProgress', () => {
+    it('fires callback during playback via requestAnimationFrame', async () => {
+      // Mock requestAnimationFrame to capture and invoke callbacks
+      const rafCallbacks: FrameRequestCallback[] = []
+      vi.stubGlobal('requestAnimationFrame', vi.fn((cb: FrameRequestCallback) => {
+        rafCallbacks.push(cb)
+        return rafCallbacks.length
+      }))
+      vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+      const player = new WebAudioPlayer()
+      const progressCalls: Array<{ currentTime: number; duration: number }> = []
+      player.onProgress((currentTime, duration) => {
+        progressCalls.push({ currentTime, duration })
+      })
+
+      await player.play('https://example.com/song.ogg')
+
+      // Trigger one rAF tick
+      expect(rafCallbacks.length).toBeGreaterThan(0)
+      rafCallbacks[rafCallbacks.length - 1](performance.now())
+
+      expect(progressCalls.length).toBeGreaterThanOrEqual(1)
+      expect(progressCalls[0].duration).toBe(mockBuffer.duration)
+    })
+
+    it('stops firing after unsubscribe', async () => {
+      const rafCallbacks: FrameRequestCallback[] = []
+      vi.stubGlobal('requestAnimationFrame', vi.fn((cb: FrameRequestCallback) => {
+        rafCallbacks.push(cb)
+        return rafCallbacks.length
+      }))
+      vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+      const player = new WebAudioPlayer()
+      const progressCalls: Array<{ currentTime: number; duration: number }> = []
+      const unsub = player.onProgress((currentTime, duration) => {
+        progressCalls.push({ currentTime, duration })
+      })
+
+      await player.play('https://example.com/song.ogg')
+
+      // Trigger one tick, should fire
+      if (rafCallbacks.length > 0) {
+        rafCallbacks[rafCallbacks.length - 1](performance.now())
+      }
+      const countAfterFirst = progressCalls.length
+
+      unsub()
+
+      // Trigger another tick, should NOT fire for this subscriber
+      if (rafCallbacks.length > 0) {
+        rafCallbacks[rafCallbacks.length - 1](performance.now())
+      }
+      expect(progressCalls.length).toBe(countAfterFirst)
+    })
+  })
+})

--- a/beakspeak/src/adapters/audio.ts
+++ b/beakspeak/src/adapters/audio.ts
@@ -1,24 +1,38 @@
 export type AudioState = 'idle' | 'loading' | 'playing' | 'error'
 
 export interface AudioPlayer {
-  play(url: string): Promise<void>
+  play(url: string, offset?: number): Promise<void>
   stop(): void
+  seek(time: number): void
   isPlaying(): boolean
   getState(): AudioState
+  getActiveUrl(): string | null
+  getProgress(): { currentTime: number; duration: number }
   onStateChange(callback: (state: AudioState) => void): () => void
+  onProgress(cb: (currentTime: number, duration: number) => void): () => void
   prefetch(url: string): void
+  getBuffer(url: string): AudioBuffer | null
 }
 
 export class WebAudioPlayer implements AudioPlayer {
   private context: AudioContext | null = null
+  private gainNode: GainNode | null = null
   private source: AudioBufferSourceNode | null = null
   private cache = new Map<string, AudioBuffer>()
   private state: AudioState = 'idle'
+  private activeUrl: string | null = null
+  private activeBuffer: AudioBuffer | null = null
+  private playbackStartTime = 0
+  private playbackOffset = 0
   private listeners: Array<(state: AudioState) => void> = []
+  private progressListeners: Array<(currentTime: number, duration: number) => void> = []
+  private rafId: number | null = null
 
   private getContext(): AudioContext {
     if (!this.context) {
       this.context = new AudioContext()
+      this.gainNode = this.context.createGain()
+      this.gainNode.connect(this.context.destination)
     }
     return this.context
   }
@@ -26,6 +40,32 @@ export class WebAudioPlayer implements AudioPlayer {
   private setState(state: AudioState) {
     this.state = state
     this.listeners.forEach(cb => cb(state))
+    if (state === 'playing') {
+      this.startProgressLoop()
+    } else {
+      this.stopProgressLoop()
+    }
+  }
+
+  private startProgressLoop() {
+    if (this.rafId !== null) return
+    const tick = () => {
+      if (this.progressListeners.length > 0) {
+        const { currentTime, duration } = this.getProgress()
+        this.progressListeners.forEach(cb => cb(currentTime, duration))
+      }
+      if (this.state === 'playing') {
+        this.rafId = requestAnimationFrame(tick)
+      }
+    }
+    this.rafId = requestAnimationFrame(tick)
+  }
+
+  private stopProgressLoop() {
+    if (this.rafId !== null) {
+      cancelAnimationFrame(this.rafId)
+      this.rafId = null
+    }
   }
 
   onStateChange(callback: (state: AudioState) => void): () => void {
@@ -43,11 +83,23 @@ export class WebAudioPlayer implements AudioPlayer {
     return this.state === 'playing'
   }
 
+  getActiveUrl(): string | null {
+    return this.activeUrl
+  }
+
   stop() {
     if (this.source) {
+      // Fade out over ~100ms to avoid click/pop artifacts
+      if (this.gainNode && this.context) {
+        const now = this.context.currentTime
+        this.gainNode.gain.setValueAtTime(this.gainNode.gain.value, now)
+        this.gainNode.gain.linearRampToValueAtTime(0, now + 0.1)
+      }
       try { this.source.stop() } catch { /* already stopped */ }
       this.source = null
     }
+    this.activeUrl = null
+    this.activeBuffer = null
     this.setState('idle')
   }
 
@@ -64,7 +116,34 @@ export class WebAudioPlayer implements AudioPlayer {
     }
   }
 
-  async play(url: string): Promise<void> {
+  getProgress(): { currentTime: number; duration: number } {
+    if (this.state !== 'playing' || !this.activeBuffer || !this.context) {
+      return { currentTime: 0, duration: 0 }
+    }
+    const elapsed = this.context.currentTime - this.playbackStartTime
+    return {
+      currentTime: this.playbackOffset + elapsed,
+      duration: this.activeBuffer.duration,
+    }
+  }
+
+  seek(time: number): void {
+    if (this.state !== 'playing' || !this.activeUrl) return
+    this.play(this.activeUrl, time)
+  }
+
+  onProgress(cb: (currentTime: number, duration: number) => void): () => void {
+    this.progressListeners.push(cb)
+    return () => {
+      this.progressListeners = this.progressListeners.filter(l => l !== cb)
+    }
+  }
+
+  getBuffer(url: string): AudioBuffer | null {
+    return this.cache.get(url) ?? null
+  }
+
+  async play(url: string, offset?: number): Promise<void> {
     this.stop()
     this.setState('loading')
 
@@ -85,14 +164,23 @@ export class WebAudioPlayer implements AudioPlayer {
         this.cache.set(url, buffer)
       }
 
+      // Reset gain to full volume before starting new clip
+      this.gainNode!.gain.setValueAtTime(1, ctx.currentTime)
+
       this.source = ctx.createBufferSource()
       this.source.buffer = buffer
-      this.source.connect(ctx.destination)
+      this.source.connect(this.gainNode!)
       this.source.onended = () => {
         this.source = null
+        this.activeUrl = null
+        this.activeBuffer = null
         this.setState('idle')
       }
-      this.source.start()
+      this.source.start(0, offset ?? 0)
+      this.playbackStartTime = ctx.currentTime
+      this.playbackOffset = offset ?? 0
+      this.activeBuffer = buffer
+      this.activeUrl = url
       this.setState('playing')
     } catch {
       this.setState('error')

--- a/beakspeak/src/components/shared/AudioButton.tsx
+++ b/beakspeak/src/components/shared/AudioButton.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { useAppStore } from '../../store/appStore'
 import type { AudioClip } from '../../core/types'
 import type { AudioState } from '../../adapters/audio'
@@ -16,48 +16,45 @@ export default function AudioButton({ clips, label, speciesId, variant = 'primar
   const lastPlayedClipId = useAppStore(s => s.lastPlayedClipId)
   const setLastPlayedClip = useAppStore(s => s.setLastPlayedClip)
 
-  const [audioState, setAudioState] = useState<AudioState>('idle')
+  const [displayState, setDisplayState] = useState<AudioState>('idle')
   const [clipIndex, setClipIndex] = useState(() => {
     const lastId = lastPlayedClipId.get(speciesId)
     if (!lastId) return 0
     const idx = clips.findIndex(c => c.xc_id === lastId)
     return idx >= 0 ? (idx + 1) % clips.length : 0
   })
-  const unsubRef = useRef<(() => void) | null>(null)
 
-  // Clean up listener on unmount
+  const clipUrls = clips.map(c => c.audio_url)
+
+  // Subscribe to player state and derive display state from activeUrl
   useEffect(() => {
-    return () => {
-      if (unsubRef.current) unsubRef.current()
-    }
-  }, [])
+    const unsub = audioPlayer.onStateChange((state: AudioState) => {
+      const activeUrl = audioPlayer.getActiveUrl()
+      if (activeUrl && clipUrls.includes(activeUrl)) {
+        setDisplayState(state)
+        if (state === 'idle') {
+          setClipIndex(prev => (prev + 1) % clips.length)
+        }
+      } else {
+        setDisplayState('idle')
+      }
+    })
+    return unsub
+  }, [audioPlayer, clipUrls.join(','), clips.length])
 
   const currentClip = clips[clipIndex]
   if (!currentClip) return null
 
   const handlePlay = useCallback(async () => {
-    if (audioState === 'playing') {
+    if (displayState === 'playing') {
       audioPlayer.stop()
-      setAudioState('idle')
       return
     }
 
     const clip = clips[clipIndex]
     setLastPlayedClip(speciesId, clip.xc_id)
-
-    // Clean up previous listener
-    if (unsubRef.current) unsubRef.current()
-
-    // Set up state listener
-    unsubRef.current = audioPlayer.onStateChange((state: AudioState) => {
-      setAudioState(state)
-      if (state === 'idle') {
-        setClipIndex(prev => (prev + 1) % clips.length)
-      }
-    })
-
     await audioPlayer.play(clip.audio_url)
-  }, [audioPlayer, clips, clipIndex, speciesId, setLastPlayedClip, audioState])
+  }, [audioPlayer, clips, clipIndex, speciesId, setLastPlayedClip, displayState])
 
   const isPrimary = variant === 'primary'
 
@@ -65,18 +62,18 @@ export default function AudioButton({ clips, label, speciesId, variant = 'primar
     <div className="flex items-center gap-2">
       <button
         onClick={handlePlay}
-        disabled={audioState === 'loading'}
+        disabled={displayState === 'loading'}
         className={`flex items-center gap-2 px-4 py-2 rounded-full font-medium transition-all ${
           isPrimary
             ? 'bg-primary text-white hover:bg-primary/90'
             : 'bg-border text-text hover:bg-border/80'
-        } ${audioState === 'loading' ? 'opacity-60' : ''}`}
+        } ${displayState === 'loading' ? 'opacity-60' : ''}`}
       >
-        {audioState === 'loading' && (
+        {displayState === 'loading' && (
           <span className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
         )}
-        {audioState === 'playing' && <span>⏹</span>}
-        {audioState !== 'loading' && audioState !== 'playing' && <span>▶</span>}
+        {displayState === 'playing' && <span>⏹</span>}
+        {displayState !== 'loading' && displayState !== 'playing' && <span>▶</span>}
         {label}
         {clips.length > 1 && (
           <span className="text-xs opacity-70">

--- a/beakspeak/src/components/shared/Spectrogram.test.tsx
+++ b/beakspeak/src/components/shared/Spectrogram.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import Spectrogram from './Spectrogram'
+import type { SpectrogramData } from '../../core/spectrogram'
+
+function makeSpectrogramData(timeBins = 10, frequencyBins = 512): SpectrogramData {
+  const magnitudes: Float32Array[] = []
+  for (let t = 0; t < timeBins; t++) {
+    magnitudes.push(new Float32Array(frequencyBins))
+  }
+  return { magnitudes, timeBins, frequencyBins, duration: 5.0, sampleRate: 44100 }
+}
+
+describe('Spectrogram', () => {
+  it('renders a canvas element', () => {
+    const data = makeSpectrogramData()
+    const { container } = render(
+      <Spectrogram data={data} currentTime={0} duration={5} isPlaying={false} onSeek={() => {}} />,
+    )
+    expect(container.querySelector('canvas')).toBeInTheDocument()
+  })
+
+  it('calls onSeek with proportional time when clicked at 75% of width', () => {
+    const data = makeSpectrogramData()
+    const onSeek = vi.fn()
+    const { container } = render(
+      <Spectrogram data={data} currentTime={0} duration={12} isPlaying={false} onSeek={onSeek} />,
+    )
+    const canvas = container.querySelector('canvas')!
+
+    // Simulate canvas having a known position and width
+    canvas.getBoundingClientRect = () => ({ left: 0, top: 0, right: 400, bottom: 80, width: 400, height: 80, x: 0, y: 0, toJSON() {} })
+
+    fireEvent.click(canvas, { clientX: 300 })
+
+    expect(onSeek).toHaveBeenCalledTimes(1)
+    expect(onSeek).toHaveBeenCalledWith(9) // 300/400 * 12 = 9
+  })
+
+  it('renders without error when data has zero time bins', () => {
+    const emptyData: SpectrogramData = {
+      magnitudes: [],
+      timeBins: 0,
+      frequencyBins: 0,
+      duration: 0,
+      sampleRate: 44100,
+    }
+    const { container } = render(
+      <Spectrogram data={emptyData} currentTime={0} duration={0} isPlaying={false} onSeek={() => {}} />,
+    )
+    expect(container.querySelector('canvas')).toBeInTheDocument()
+  })
+
+  it('does not fire onSeek when duration is zero', () => {
+    const emptyData: SpectrogramData = {
+      magnitudes: [],
+      timeBins: 0,
+      frequencyBins: 0,
+      duration: 0,
+      sampleRate: 44100,
+    }
+    const onSeek = vi.fn()
+    const { container } = render(
+      <Spectrogram data={emptyData} currentTime={0} duration={0} isPlaying={false} onSeek={onSeek} />,
+    )
+    const canvas = container.querySelector('canvas')!
+    canvas.getBoundingClientRect = () => ({ left: 0, top: 0, right: 400, bottom: 80, width: 400, height: 80, x: 0, y: 0, toJSON() {} })
+
+    fireEvent.click(canvas, { clientX: 200 })
+
+    expect(onSeek).not.toHaveBeenCalled()
+  })
+})

--- a/beakspeak/src/components/shared/Spectrogram.tsx
+++ b/beakspeak/src/components/shared/Spectrogram.tsx
@@ -1,0 +1,140 @@
+import { useRef, useEffect, useCallback } from 'react'
+import type { SpectrogramData } from '../../core/spectrogram'
+
+interface Props {
+  data: SpectrogramData
+  currentTime: number
+  duration: number
+  isPlaying: boolean
+  onSeek: (time: number) => void
+}
+
+const FALLBACK_BG = '#FAF8F5'
+const FALLBACK_PRIMARY = '#8B6F47'
+const FALLBACK_SECONDARY = '#5B8A72'
+
+function parseHexColor(hex: string): [number, number, number] {
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  return [r, g, b]
+}
+
+function lerpColor(a: [number, number, number], b: [number, number, number], t: number): [number, number, number] {
+  return [
+    Math.round(a[0] + (b[0] - a[0]) * t),
+    Math.round(a[1] + (b[1] - a[1]) * t),
+    Math.round(a[2] + (b[2] - a[2]) * t),
+  ]
+}
+
+function getThemeColor(prop: string, fallback: string): string {
+  if (typeof document === 'undefined') return fallback
+  return getComputedStyle(document.documentElement).getPropertyValue(prop).trim() || fallback
+}
+
+function drawSpectrogram(
+  canvas: HTMLCanvasElement,
+  data: SpectrogramData,
+  currentTime: number,
+  duration: number,
+) {
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+
+  const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1
+  const cssWidth = canvas.clientWidth
+  const cssHeight = canvas.clientHeight
+  canvas.width = cssWidth * dpr
+  canvas.height = cssHeight * dpr
+  ctx.scale(dpr, dpr)
+
+  const bgColor = parseHexColor(getThemeColor('--color-bg', FALLBACK_BG))
+  const primaryColor = parseHexColor(getThemeColor('--color-primary', FALLBACK_PRIMARY))
+  const secondaryHex = getThemeColor('--color-secondary', FALLBACK_SECONDARY)
+
+  // Empty data — flat gray canvas
+  if (data.timeBins === 0) {
+    ctx.fillStyle = `rgb(${bgColor[0]}, ${bgColor[1]}, ${bgColor[2]})`
+    ctx.fillRect(0, 0, cssWidth, cssHeight)
+    return
+  }
+
+  // Draw heatmap
+  const colWidth = cssWidth / data.timeBins
+  const rowHeight = cssHeight / data.frequencyBins
+
+  for (let t = 0; t < data.timeBins; t++) {
+    const mags = data.magnitudes[t]
+    const x = t * colWidth
+    for (let f = 0; f < data.frequencyBins; f++) {
+      // Low frequencies at bottom: invert the y-axis
+      const y = (data.frequencyBins - 1 - f) * rowHeight
+      const mag = mags[f]
+      const [r, g, b] = lerpColor(bgColor, primaryColor, mag)
+      ctx.fillStyle = `rgb(${r}, ${g}, ${b})`
+      ctx.fillRect(x, y, Math.ceil(colWidth), Math.ceil(rowHeight))
+    }
+  }
+
+  // Draw playhead
+  if (currentTime > 0 && duration > 0) {
+    const playheadX = (currentTime / duration) * cssWidth
+    ctx.strokeStyle = secondaryHex
+    ctx.lineWidth = 2
+    ctx.beginPath()
+    ctx.moveTo(playheadX, 0)
+    ctx.lineTo(playheadX, cssHeight)
+    ctx.stroke()
+  }
+}
+
+export default function Spectrogram({ data, currentTime, duration, isPlaying: _isPlaying, onSeek }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  // Draw heatmap when data changes
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    drawSpectrogram(canvas, data, currentTime, duration)
+  }, [data])
+
+  // Redraw playhead on progress updates
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    drawSpectrogram(canvas, data, currentTime, duration)
+  }, [currentTime, duration, data])
+
+  // Handle resize
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const observer = new ResizeObserver(() => {
+      drawSpectrogram(canvas, data, currentTime, duration)
+    })
+    observer.observe(canvas)
+    return () => observer.disconnect()
+  }, [data, currentTime, duration])
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current
+      if (!canvas || duration <= 0) return
+      const rect = canvas.getBoundingClientRect()
+      const x = e.clientX - rect.left
+      const seekTime = (x / rect.width) * duration
+      onSeek(seekTime)
+    },
+    [duration, onSeek],
+  )
+
+  return (
+    <canvas
+      ref={canvasRef}
+      onClick={handleClick}
+      className="w-full cursor-pointer rounded"
+      style={{ height: 80 }}
+    />
+  )
+}

--- a/beakspeak/src/core/spectrogram.test.ts
+++ b/beakspeak/src/core/spectrogram.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { computeSpectrogram } from './spectrogram'
+
+function makeAudioBuffer(samples: Float32Array, sampleRate: number) {
+  return {
+    getChannelData: (_channel: number) => samples,
+    length: samples.length,
+    duration: samples.length / sampleRate,
+    sampleRate,
+    numberOfChannels: 1,
+  } as unknown as AudioBuffer
+}
+
+describe('computeSpectrogram', () => {
+  it('produces correct output shape for given sample count', () => {
+    const sampleRate = 44100
+    const samples = new Float32Array(4096)
+    const buffer = makeAudioBuffer(samples, sampleRate)
+    const result = computeSpectrogram(buffer)
+
+    // defaults: fftSize=1024, hopSize=512
+    expect(result.frequencyBins).toBe(512)
+    expect(result.timeBins).toBe(Math.ceil(4096 / 512))
+    expect(result.magnitudes).toHaveLength(result.timeBins)
+    expect(result.magnitudes[0]).toHaveLength(512)
+    expect(result.duration).toBe(4096 / sampleRate)
+    expect(result.sampleRate).toBe(sampleRate)
+  })
+
+  it('detects a 440Hz sine wave at the correct frequency bin', () => {
+    const sampleRate = 44100
+    const duration = 0.5 // 22050 samples
+    const numSamples = Math.round(sampleRate * duration)
+    const samples = new Float32Array(numSamples)
+    for (let i = 0; i < numSamples; i++) {
+      samples[i] = Math.sin(2 * Math.PI * 440 * i / sampleRate)
+    }
+    const buffer = makeAudioBuffer(samples, sampleRate)
+    const fftSize = 1024
+    const result = computeSpectrogram(buffer, { fftSize })
+
+    // Expected peak bin: 440 * fftSize / sampleRate ≈ 10.2
+    const expectedBin = Math.round(440 * fftSize / sampleRate)
+
+    // Find the bin with the highest magnitude in the middle time frame
+    const midFrame = result.magnitudes[Math.floor(result.timeBins / 2)]
+    let peakBin = 0
+    let peakValue = 0
+    for (let i = 0; i < midFrame.length; i++) {
+      if (midFrame[i] > peakValue) {
+        peakValue = midFrame[i]
+        peakBin = i
+      }
+    }
+
+    expect(peakBin).toBe(expectedBin)
+    expect(peakValue).toBeGreaterThan(0.5)
+
+    // Bins far from the peak should be much quieter
+    const farBin = Math.min(expectedBin + 50, result.frequencyBins - 1)
+    expect(midFrame[farBin]).toBeLessThan(0.1)
+  })
+
+  it('produces near-zero magnitudes for silence', () => {
+    const samples = new Float32Array(2048) // all zeros
+    const buffer = makeAudioBuffer(samples, 44100)
+    const result = computeSpectrogram(buffer)
+
+    for (const frame of result.magnitudes) {
+      for (let i = 0; i < frame.length; i++) {
+        expect(frame[i]).toBeLessThan(0.01)
+      }
+    }
+  })
+
+  it('respects custom fftSize option', () => {
+    const samples = new Float32Array(4096)
+    const buffer = makeAudioBuffer(samples, 44100)
+    const result = computeSpectrogram(buffer, { fftSize: 2048 })
+
+    expect(result.frequencyBins).toBe(1024)
+    expect(result.magnitudes[0]).toHaveLength(1024)
+    // hopSize defaults to fftSize/2 = 1024
+    expect(result.timeBins).toBe(Math.ceil(4096 / 1024))
+  })
+
+  it('returns empty data for a zero-length buffer', () => {
+    const buffer = makeAudioBuffer(new Float32Array(0), 44100)
+    const result = computeSpectrogram(buffer)
+
+    expect(result.magnitudes).toEqual([])
+    expect(result.timeBins).toBe(0)
+    expect(result.frequencyBins).toBe(0)
+    expect(result.duration).toBe(0)
+    expect(result.sampleRate).toBe(44100)
+  })
+})

--- a/beakspeak/src/core/spectrogram.ts
+++ b/beakspeak/src/core/spectrogram.ts
@@ -1,0 +1,111 @@
+export interface SpectrogramData {
+  magnitudes: Float32Array[]
+  timeBins: number
+  frequencyBins: number
+  duration: number
+  sampleRate: number
+}
+
+export function computeSpectrogram(
+  buffer: AudioBuffer,
+  options?: { fftSize?: number; hopSize?: number },
+): SpectrogramData {
+  const sampleRate = buffer.sampleRate
+  const length = buffer.length
+
+  if (length === 0) {
+    return { magnitudes: [], timeBins: 0, frequencyBins: 0, duration: 0, sampleRate }
+  }
+
+  const fftSize = options?.fftSize ?? 1024
+  const hopSize = options?.hopSize ?? fftSize / 2
+  const frequencyBins = fftSize / 2
+  const samples = buffer.getChannelData(0)
+  const timeBins = Math.ceil(length / hopSize)
+
+  const hannWindow = new Float32Array(fftSize)
+  for (let i = 0; i < fftSize; i++) {
+    hannWindow[i] = 0.5 * (1 - Math.cos((2 * Math.PI * i) / (fftSize - 1)))
+  }
+
+  const magnitudes: Float32Array[] = []
+  let globalMax = 0
+
+  for (let t = 0; t < timeBins; t++) {
+    const offset = t * hopSize
+    const real = new Float64Array(fftSize)
+    const imag = new Float64Array(fftSize)
+
+    for (let i = 0; i < fftSize; i++) {
+      const sampleIdx = offset + i
+      real[i] = (sampleIdx < length ? samples[sampleIdx] : 0) * hannWindow[i]
+    }
+
+    fft(real, imag)
+
+    const mags = new Float32Array(frequencyBins)
+    for (let i = 0; i < frequencyBins; i++) {
+      mags[i] = Math.sqrt(real[i] * real[i] + imag[i] * imag[i])
+      if (mags[i] > globalMax) globalMax = mags[i]
+    }
+    magnitudes.push(mags)
+  }
+
+  if (globalMax > 0) {
+    for (let t = 0; t < magnitudes.length; t++) {
+      for (let i = 0; i < frequencyBins; i++) {
+        magnitudes[t][i] /= globalMax
+      }
+    }
+  }
+
+  return {
+    magnitudes,
+    timeBins,
+    frequencyBins,
+    duration: buffer.duration,
+    sampleRate,
+  }
+}
+
+/** In-place radix-2 Cooley-Tukey FFT. Arrays must be power-of-2 length. */
+function fft(real: Float64Array, imag: Float64Array): void {
+  const n = real.length
+  if (n <= 1) return
+
+  // Bit-reversal permutation
+  let j = 0
+  for (let i = 0; i < n - 1; i++) {
+    if (i < j) {
+      let tmp = real[i]; real[i] = real[j]; real[j] = tmp
+      tmp = imag[i]; imag[i] = imag[j]; imag[j] = tmp
+    }
+    let m = n >> 1
+    while (m >= 1 && j >= m) {
+      j -= m
+      m >>= 1
+    }
+    j += m
+  }
+
+  // Butterfly passes
+  for (let size = 2; size <= n; size *= 2) {
+    const halfSize = size / 2
+    const angle = -2 * Math.PI / size
+    for (let i = 0; i < n; i += size) {
+      for (let k = 0; k < halfSize; k++) {
+        const theta = angle * k
+        const cos = Math.cos(theta)
+        const sin = Math.sin(theta)
+        const idx = i + k
+        const idx2 = idx + halfSize
+        const tReal = cos * real[idx2] - sin * imag[idx2]
+        const tImag = sin * real[idx2] + cos * imag[idx2]
+        real[idx2] = real[idx] - tReal
+        imag[idx2] = imag[idx] - tImag
+        real[idx] += tReal
+        imag[idx] += tImag
+      }
+    }
+  }
+}

--- a/beakspeak/src/test/setup.ts
+++ b/beakspeak/src/test/setup.ts
@@ -1,1 +1,14 @@
 import '@testing-library/jest-dom'
+
+// jsdom stubs for canvas and ResizeObserver
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver
+}
+
+HTMLCanvasElement.prototype.getContext = function () {
+  return null
+} as unknown as typeof HTMLCanvasElement.prototype.getContext

--- a/rpi/implementation/audio-improvements-issues-2026-04-16.md
+++ b/rpi/implementation/audio-improvements-issues-2026-04-16.md
@@ -1,0 +1,572 @@
+# Audio Improvements — Issues
+
+Parent PRD: `rpi/plans/audio-improvements-prd-2026-04-15.md`
+
+Dependency graph:
+
+```
+Issue 1 (state fix) ──> Issue 2 (progress/seek) ──┐
+                                                    ├──> Issue 5 (BirdCard integration)
+Issue 3 (spectrogram compute) ──> Issue 4 (canvas) ┘
+
+Issue 6 (license + quality) ──┐
+                               ├──> Issue 8 (pipeline re-run)
+Issue 7 (smart trimming) ─────┘
+```
+
+Issues 1, 3, 6, and 7 can start in parallel.
+
+---
+
+## Issue 1: Fix audio state coordination (AudioPlayer + AudioButton)
+
+**Type**: AFK
+**Blocked by**: None — can start immediately
+
+### Parent PRD
+
+`rpi/plans/audio-improvements-prd-2026-04-15.md`
+
+### What to build
+
+End-to-end fix for the bug where multiple AudioButton instances show incorrect playing/loading state when the user rapidly switches between clips.
+
+In the AudioPlayer (`adapters/audio.ts`):
+- Track the currently active URL internally. Expose it via `getActiveUrl(): string | null`.
+- Route audio output through a `GainNode` so that `stop()` can apply a ~100ms linear fade-out ramp before disconnecting the source, rather than an abrupt cut. This provides the brief fade transition described in the PRD's "Fade-Out on Stop" section.
+- Ensure `play()` still calls `stop()` before starting a new clip (existing behavior), so the fade applies when switching.
+
+In AudioButton (`components/shared/AudioButton.tsx`):
+- Remove the local `audioState` / `onStateChange` subscription pattern that causes the bug.
+- Instead, subscribe to the player's state and compare `getActiveUrl()` against the button's own clip URLs to decide whether to show playing/loading/idle.
+- Preserve existing behavior: toggle play/stop on tap, cycle to the next clip on completion, track last-played clip per species.
+
+In LearnSession: no changes needed — it already calls `audioPlayer.stop()` on swipe, which continues to work.
+
+### How to verify
+
+- **Manual**: Open a BirdCard with both song and call clips. Tap "Play Song", then immediately tap "Play Call". Verify: Song button shows idle, Call button shows playing, audio is the call clip, and there is a brief fade (no click/pop) during the switch.
+- **Automated**: Unit tests on AudioPlayer:
+  - `play(urlA)` then `play(urlB)`: `getActiveUrl()` returns `urlB`, state is `'playing'`
+  - `stop()`: `getActiveUrl()` returns `null`, state is `'idle'`
+  - `play(urlA)` then `stop()`: state transitions through `'playing'` → `'idle'`
+
+### Acceptance criteria
+
+- [ ] Given two AudioButtons on the same BirdCard, when the user taps one while the other is playing, then only the newly tapped button shows as playing and the previous button shows idle
+- [ ] Given audio is playing, when `stop()` is called, then audio fades out over ~100ms rather than cutting abruptly
+- [ ] Given audio is playing, when `play()` is called with a different URL, then `getActiveUrl()` returns the new URL
+- [ ] Given no audio is playing, when `getActiveUrl()` is called, then it returns `null`
+- [ ] Given a user swipes between BirdCards in LearnSession, when audio is playing, then audio stops and the button on the previous card does not remain in a playing state
+
+### User stories addressed
+
+- User story 1: Only one audio clip playing at a time
+- User story 2: Previous button immediately shows idle when switching clips
+- User story 3: Brief visual fade when switching between clips
+- User story 20: Audio stops immediately on swipe between BirdCards
+
+### Tasks
+
+#### 1.1. Add GainNode, activeUrl tracking, fade-out to WebAudioPlayer
+
+**Type**: WRITE
+**Output**: `audio.ts` has GainNode routing, `getActiveUrl()`, fade-out `stop()`
+**Depends on**: none
+
+- [x] Modify `adapters/audio.ts`. Add a private `activeUrl: string | null` field and expose it via `getActiveUrl()` on both the `AudioPlayer` interface and `WebAudioPlayer` class. Create a persistent `GainNode` in the audio routing chain (source → gain → destination) so that `stop()` can ramp gain to 0 over ~100ms via `GainNode.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.1)` before disconnecting the source. In `play()`, reset gain to 1 before starting the new source and set `activeUrl` to the URL. In `stop()` and in the `onended` callback, set `activeUrl` to `null`. Ensure `play()` still calls `stop()` first so the fade applies when switching clips.
+
+---
+
+#### 1.2. Unit tests for AudioPlayer state coordination
+
+**Type**: TEST
+**Output**: `adapters/audio.test.ts` passes
+**Depends on**: 1.1
+
+- [x] Create `adapters/audio.test.ts`. Follow the existing test pattern in `core/manifest.test.ts` (vitest `describe`/`it` blocks). Mock `AudioContext`, `AudioBuffer`, and `AudioBufferSourceNode` since tests run in jsdom. Test: `play(urlA)` → `getActiveUrl()` returns `urlA` and state is `'playing'`. Test: `play(urlA)` then `play(urlB)` → `getActiveUrl()` returns `urlB`. Test: `stop()` → `getActiveUrl()` returns `null` and state is `'idle'`. Test: state transitions follow `idle → loading → playing → idle` sequence.
+
+---
+
+#### 1.3. Refactor AudioButton to use centralized active URL state
+
+**Type**: WRITE
+**Output**: Two AudioButtons on the same BirdCard correctly show only the active one as playing
+**Depends on**: 1.1
+
+- [x] Modify `components/shared/AudioButton.tsx`. Remove the local `audioState` useState and `unsubRef`-based `onStateChange` subscription pattern that causes the state confusion bug. Instead, subscribe to the player's `onStateChange` but derive the display state by comparing `audioPlayer.getActiveUrl()` against the button's own clip URLs — if the active URL matches one of this button's clips, show the player's current state; otherwise show `'idle'`. Preserve all existing behavior: toggle play/stop on tap, cycle to the next clip on completion via the clip index, and track last-played clip per species via `setLastPlayedClip`.
+
+---
+
+## Issue 2: Add progress tracking and seeking to AudioPlayer
+
+**Type**: AFK
+**Blocked by**: Issue 1
+
+### Parent PRD
+
+`rpi/plans/audio-improvements-prd-2026-04-15.md`
+
+### What to build
+
+Extend the AudioPlayer to support playback progress reporting and seeking, as described in the PRD's "Seeking via Web Audio API" section. These are the foundational capabilities that the spectrogram UI (Issue 5) will consume.
+
+Changes to AudioPlayer (`adapters/audio.ts`):
+- Extend `play(url: string, offset?: number)` to accept an optional start offset in seconds. Internally, this passes the offset to `AudioBufferSourceNode.start(0, offset)`.
+- Add `seek(time: number)` as a convenience method: stops the current source and calls `play(activeUrl, time)`. No-op if nothing is playing.
+- Add `getProgress(): { currentTime: number; duration: number }`. Track the start time of the current playback (from `AudioContext.currentTime`) and the buffer duration. `currentTime` is computed as elapsed time since start plus any seek offset.
+- Add `onProgress(cb: (currentTime: number, duration: number) => void): () => void`. Starts a `requestAnimationFrame` loop when audio is playing that calls the callback with current progress. Returns an unsubscribe function. Loop stops automatically when playback ends.
+- Add `getBuffer(url: string): AudioBuffer | null` to expose cached buffers. The spectrogram renderer (Issue 3) needs the raw audio data.
+
+Update the `AudioPlayer` interface type to include the new methods.
+
+### How to verify
+
+- **Automated**: Unit tests:
+  - `play(url, 5.0)`: playback starts at 5s offset, `getProgress()` returns `{ currentTime: ~5.0, duration: bufferDuration }`
+  - `seek(10.0)` while playing: `getProgress().currentTime` is ~10.0, `getActiveUrl()` is unchanged
+  - `seek()` while stopped: no-op, no error
+  - `onProgress` callback fires during playback with increasing `currentTime` values
+  - `getBuffer(url)` returns the cached `AudioBuffer` after `play(url)` completes
+
+### Acceptance criteria
+
+- [ ] Given audio is playing, when `getProgress()` is called, then it returns `{ currentTime, duration }` where `currentTime` increases over time and `duration` matches the buffer length
+- [ ] Given audio is playing at position 3s, when `seek(10.0)` is called, then playback resumes from 10s of the same clip without interruption in the audio output (beyond the seek discontinuity)
+- [ ] Given audio is stopped, when `seek()` is called, then nothing happens and no error is thrown
+- [ ] Given `play(url, 7.0)` is called, then playback starts from the 7-second mark
+- [ ] Given a URL has been played, when `getBuffer(url)` is called, then the cached `AudioBuffer` is returned
+- [ ] Given a URL has not been played or prefetched, when `getBuffer(url)` is called, then `null` is returned
+
+### User stories addressed
+
+- User story 6: Playhead animates across spectrogram (foundational — progress tracking)
+- User story 7: Click spectrogram to seek while playing (foundational — seek capability)
+- User story 8: Click spectrogram when stopped to seek and play (foundational — play with offset)
+
+### Tasks
+
+#### 2.1. Add play offset, seek, progress tracking, and getBuffer to AudioPlayer
+
+**Type**: WRITE
+**Output**: `audio.ts` extended with offset param, `seek()`, `getProgress()`, `onProgress()`, `getBuffer()`
+**Depends on**: 1.2
+
+- [ ] Modify `adapters/audio.ts`. Extend `play(url: string, offset?: number)` to pass the offset to `source.start(0, offset ?? 0)`. Track `playbackStartTime` (from `AudioContext.currentTime` at the moment `source.start` is called) and `playbackOffset` (the offset value) as private fields for progress calculation. Add `seek(time: number)`: if currently playing, call `play(activeUrl, time)`; if stopped, no-op. Add `getProgress(): { currentTime: number; duration: number }` that returns `{ currentTime: playbackOffset + (ctx.currentTime - playbackStartTime), duration: buffer.duration }`, or `{ currentTime: 0, duration: 0 }` if not playing. Add `onProgress(cb)`: manage a `requestAnimationFrame` loop that calls the callback with `getProgress()` values while state is `'playing'`; return an unsubscribe function; start/stop the rAF loop on state transitions. Add `getBuffer(url: string): AudioBuffer | null` that returns `this.cache.get(url) ?? null`. Update the `AudioPlayer` interface type with all new method signatures.
+
+---
+
+#### 2.2. Unit tests for progress and seeking
+
+**Type**: TEST
+**Output**: Extended `adapters/audio.test.ts` passes
+**Depends on**: 2.1
+
+- [ ] Extend `adapters/audio.test.ts` with a new `describe` block for progress and seeking. Test: `play(url, 5.0)` → `getProgress().currentTime` is approximately 5.0. Test: `seek(10.0)` while playing → `getProgress().currentTime` is approximately 10.0 and `getActiveUrl()` is unchanged. Test: `seek()` while stopped → no error, no state change, `getActiveUrl()` remains `null`. Test: `getBuffer(knownUrl)` returns the cached `AudioBuffer` after play. Test: `getBuffer(unknownUrl)` returns `null`. The rAF-based `onProgress` callback may need a manual timer advance or mock `requestAnimationFrame` to test.
+
+---
+
+## Issue 3: Spectrogram computation engine
+
+**Type**: AFK
+**Blocked by**: None — can start immediately
+
+### Parent PRD
+
+`rpi/plans/audio-improvements-prd-2026-04-15.md`
+
+### What to build
+
+A pure TypeScript module that computes spectrogram data from a Web Audio API `AudioBuffer`, as described in the PRD's "Spectrogram Computation" section.
+
+New file `core/spectrogram.ts`:
+- Implement a windowed FFT (Hann window, default 1024-sample frames) from scratch. No external library.
+- Export `computeSpectrogram(buffer: AudioBuffer, options?: { fftSize?: number; hopSize?: number }): SpectrogramData`.
+  - Reads channel 0 data via `buffer.getChannelData(0)`.
+  - Slides the FFT window across the signal with `hopSize` (default: half of `fftSize`) step.
+  - For each window: apply Hann window, compute FFT, take magnitude of each frequency bin, normalize to 0-1 range.
+  - Output: `SpectrogramData` type containing `{ magnitudes: Float32Array[]; timeBins: number; frequencyBins: number; duration: number; sampleRate: number }`.
+- The module must have zero DOM, React, or browser API dependencies (except the `AudioBuffer` type for the input signature). This keeps it testable in a Node/jsdom environment.
+
+### How to verify
+
+- **Automated**: Unit tests in `core/spectrogram.test.ts`:
+  - Silence input: all magnitudes near zero
+  - Pure sine wave at known frequency: magnitude peak at the expected frequency bin, low elsewhere
+  - Output shape: `timeBins` matches expected `ceil(bufferLength / hopSize)`, `frequencyBins` matches `fftSize / 2`
+  - Zero-length buffer: returns empty data (0 time bins) without error
+  - Different `fftSize` options produce different output resolutions
+
+### Acceptance criteria
+
+- [ ] Given a silent AudioBuffer, when `computeSpectrogram()` is called, then all magnitude values are near zero (< 0.01)
+- [ ] Given a 440Hz sine wave AudioBuffer, when `computeSpectrogram()` is called, then the magnitude peak is at the frequency bin closest to 440Hz
+- [ ] Given an AudioBuffer of N samples and default options, when `computeSpectrogram()` is called, then `timeBins` equals `ceil(N / hopSize)` and `frequencyBins` equals `fftSize / 2`
+- [ ] Given a zero-length AudioBuffer, when `computeSpectrogram()` is called, then it returns a `SpectrogramData` with `timeBins: 0` and no error
+- [ ] The module imports no DOM, React, or browser-specific modules
+
+### User stories addressed
+
+- User story 4: See a spectrogram of the current clip (foundational — computation layer)
+
+### Tasks
+
+#### 3.1. Implement FFT and computeSpectrogram
+
+**Type**: WRITE
+**Output**: New `core/spectrogram.ts` exports `computeSpectrogram` and `SpectrogramData`
+**Depends on**: none
+
+- [ ] Create `core/spectrogram.ts`. Export a `SpectrogramData` type: `{ magnitudes: Float32Array[]; timeBins: number; frequencyBins: number; duration: number; sampleRate: number }`. Implement a Hann window function and a radix-2 Cooley-Tukey FFT (pad input to next power of 2 if needed). Export `computeSpectrogram(buffer: AudioBuffer, options?: { fftSize?: number; hopSize?: number }): SpectrogramData` with defaults `fftSize: 1024`, `hopSize: 512`. It reads channel 0 data via `buffer.getChannelData(0)`, slides the FFT window across the signal with `hopSize` step, and for each window: applies the Hann window, computes FFT, takes magnitude of each frequency bin (first half only — `fftSize / 2`), and normalizes to 0-1 range (relative to the global max magnitude across all windows). Returns `SpectrogramData` with `timeBins = ceil(sampleCount / hopSize)` and `frequencyBins = fftSize / 2`. For zero-length buffers, return `{ magnitudes: [], timeBins: 0, frequencyBins: 0, duration: 0, sampleRate: buffer.sampleRate }`. The module must have zero DOM, React, or browser-specific imports.
+
+---
+
+#### 3.2. Unit tests for spectrogram computation
+
+**Type**: TEST
+**Output**: `core/spectrogram.test.ts` passes
+**Depends on**: 3.1
+
+- [ ] Create `core/spectrogram.test.ts`. Follow the existing test pattern in `core/manifest.test.ts`. Create a helper function `makeAudioBuffer(samples: Float32Array, sampleRate: number)` that returns a mock object satisfying the `AudioBuffer` interface (with `getChannelData()`, `length`, `duration`, `sampleRate`). Test: silence (all zeros) → all magnitudes < 0.01. Test: 440Hz sine wave at 44100Hz sample rate → magnitude peak is at the frequency bin closest to 440Hz (bin index ≈ 440 * fftSize / sampleRate), with other bins significantly lower. Test: output shape — given N samples and default options, `timeBins` equals `Math.ceil(N / 512)` and `frequencyBins` equals 512. Test: zero-length buffer → `timeBins: 0`, no error. Test: passing custom `fftSize: 2048` produces `frequencyBins: 1024`.
+
+---
+
+## Issue 4: Spectrogram canvas component
+
+**Type**: AFK
+**Blocked by**: Issue 3
+
+### Parent PRD
+
+`rpi/plans/audio-improvements-prd-2026-04-15.md`
+
+### What to build
+
+A React component that renders a `SpectrogramData` object as a heatmap on an HTML `<canvas>`, as described in the PRD's "Spectrogram Rendering and Interaction" section.
+
+New file `components/shared/Spectrogram.tsx`:
+- Props: `data: SpectrogramData`, `currentTime: number`, `duration: number`, `isPlaying: boolean`, `onSeek: (time: number) => void`.
+- Renders a `<canvas>` element, full width of its container, ~80px tall (configurable via prop or CSS).
+- On mount (and when `data` changes): draw the full spectrogram heatmap. Map magnitude values (0-1) to a color gradient using the app's theme colors — background color for silence, primary color for loud frequencies.
+- Draw a vertical playhead line at the position `(currentTime / duration) * canvasWidth`. The playhead should be a contrasting color (e.g., white or the secondary theme color) so it's visible against the heatmap.
+- On click: compute `seekTime = (clickX / canvasWidth) * duration` and call `onSeek(seekTime)`.
+- Handle canvas resize (window resize, container reflow) by redrawing.
+
+This component is a static renderer with a click handler. Playhead animation timing is driven by the parent (BirdCard, Issue 5) passing updated `currentTime` values. This component does not manage any audio state.
+
+### How to verify
+
+- **Manual**: Import the component in a test harness or Storybook-like setup. Pass it synthetic `SpectrogramData` (e.g., from the test helpers in Issue 3). Verify: heatmap renders with theme colors, playhead line appears at the correct horizontal position for a given `currentTime`, clicking fires `onSeek` with the expected time value.
+- **Automated**: The rendering itself is not unit-tested (canvas). The `onSeek` callback can be tested by simulating a click event on the canvas and asserting the computed time value.
+
+### Acceptance criteria
+
+- [ ] Given valid `SpectrogramData`, when the component mounts, then a colored heatmap is drawn on the canvas with frequency on the y-axis and time on the x-axis
+- [ ] Given `currentTime` of half the `duration`, when the component renders, then the playhead line is at the horizontal midpoint of the canvas
+- [ ] Given the user clicks at 75% of the canvas width on a 12-second clip, when `onSeek` fires, then it is called with a value of approximately 9.0
+- [ ] Given the container resizes, when the component re-renders, then the canvas redraws at the new dimensions without distortion
+- [ ] Given `SpectrogramData` with zero time bins, when the component renders, then it shows an empty/gray canvas without error
+- [ ] The heatmap color gradient uses the app's theme colors (primary for loud, background for silent)
+
+### User stories addressed
+
+- User story 4: See a spectrogram of the current clip (rendering layer)
+- User story 18: Spectrogram colors match the app's visual theme
+
+### Tasks
+
+#### 4.1. Create Spectrogram.tsx canvas component
+
+**Type**: WRITE
+**Output**: Component renders heatmap with theme colors, playhead line, click-to-seek
+**Depends on**: 3.1
+
+- [ ] Create `components/shared/Spectrogram.tsx`. Props: `data: SpectrogramData`, `currentTime: number`, `duration: number`, `isPlaying: boolean`, `onSeek: (time: number) => void`. Render a `<canvas>` element, full width of its container, ~80px tall. On mount and when `data` changes, draw the full spectrogram heatmap using the 2D canvas context: iterate over `data.magnitudes` (time bins on x-axis, frequency bins on y-axis with low frequencies at bottom), mapping each magnitude value (0-1) to a color gradient from `--color-bg` (#FAF8F5) for silence to `--color-primary` (#8B6F47) for loud. Read theme colors from CSS custom properties via `getComputedStyle`. Draw a vertical playhead line at position `(currentTime / duration) * canvasWidth` using `--color-secondary` (#5B8A72) or white for contrast. Only draw the playhead when `currentTime > 0`. On click, compute `seekTime = (event.offsetX / canvas.clientWidth) * duration` and call `onSeek(seekTime)`. Handle canvas resize via `ResizeObserver` — update `canvas.width`/`canvas.height` to match CSS dimensions (for sharp rendering on HiDPI) and redraw. For zero-bin data, render a flat gray canvas.
+
+---
+
+## Issue 5: BirdCard spectrogram integration (layout + playhead + seek)
+
+**Type**: HITL (verify spectrogram sizing, color contrast, and tap accuracy on real mobile devices)
+**Blocked by**: Issues 2, 4
+
+### Parent PRD
+
+`rpi/plans/audio-improvements-prd-2026-04-15.md`
+
+### What to build
+
+Wire the Spectrogram component into BirdCard so that every card in the Learn flow shows an interactive, animated spectrogram. This is the convergence point for the UI-side audio work.
+
+Changes to BirdCard (`components/learn/BirdCard.tsx`):
+- Add the `Spectrogram` component between the audio buttons and the mnemonic text.
+- Track which clip set is active (songs or calls) and which clip index, so the spectrogram updates when the user switches. Default to the first song clip when no audio has been played.
+- Compute `SpectrogramData` from the active clip's `AudioBuffer` (via `audioPlayer.getBuffer(url)` + `computeSpectrogram()`). Cache the result so it's not recomputed on every render.
+- Subscribe to `audioPlayer.onProgress()` to drive the playhead `currentTime` prop.
+- Read `audioPlayer.getState()` and `getActiveUrl()` to set the `isPlaying` prop.
+- Pass `audioPlayer.seek()` as the `onSeek` handler. When audio is stopped and the user clicks the spectrogram, call `audioPlayer.play(clipUrl, seekTime)` to start from that position.
+- When the active clip changes (user taps a different AudioButton), recompute the spectrogram data for the new clip.
+
+The spectrogram should be visible at all times (not collapsed when idle). When idle, it shows the full static heatmap with no playhead, giving users a preview of the clip's frequency structure before they press play.
+
+### How to verify
+
+- **Manual**:
+  1. Open a BirdCard in the Learn flow. Verify: spectrogram is visible below the audio buttons showing the first song clip's frequency structure.
+  2. Tap "Play Song". Verify: playhead animates left-to-right across the spectrogram in sync with audio. Playhead reaches the right edge when the clip ends.
+  3. While playing, tap "Play Call". Verify: spectrogram updates to show the call clip's frequency structure, playhead resets and animates for the new clip.
+  4. While playing, click the middle of the spectrogram. Verify: audio jumps to the midpoint of the clip and continues playing.
+  5. Stop audio. Verify: spectrogram remains visible showing the full static heatmap, no playhead.
+  6. While stopped, click a position on the spectrogram. Verify: audio starts playing from that position.
+  7. Swipe to the next BirdCard. Verify: audio stops, new card shows its own spectrogram.
+  8. Test on a mobile device: verify the spectrogram is large enough to see frequency banding and tap accurately for seeking.
+
+### Acceptance criteria
+
+- [ ] Given a BirdCard with song clips, when no audio is playing, then the spectrogram shows the first song clip's full heatmap with no playhead
+- [ ] Given audio is playing, when the spectrogram renders, then a playhead line animates from left to right in sync with the audio progress
+- [ ] Given audio is playing, when the user clicks a position on the spectrogram, then audio seeks to that time position and continues playing
+- [ ] Given audio is stopped, when the user clicks a position on the spectrogram, then audio starts playing from that position
+- [ ] Given the user taps "Play Call" while viewing the song spectrogram, then the spectrogram updates to show the call clip's frequency data
+- [ ] Given the user swipes to the next BirdCard, then audio stops and the new card displays its own spectrogram
+- [ ] Given a mobile viewport (~375px wide), the spectrogram is tall enough (~80px) to visually distinguish frequency banding and to tap seek positions accurately
+
+### User stories addressed
+
+- User story 5: Spectrogram shows full clip shape when idle
+- User story 6: Playhead animates across spectrogram during playback
+- User story 7: Click spectrogram to seek while playing
+- User story 8: Click spectrogram when stopped to seek and play
+- User story 9: Spectrogram updates when switching between song and call
+- User story 17: Spectrogram usable on mobile screens
+
+### Tasks
+
+#### 5.1. Wire Spectrogram into BirdCard with audio state
+
+**Type**: WRITE
+**Output**: BirdCard shows animated, seekable spectrogram for the active clip
+**Depends on**: 2.2, 4.1
+
+- [ ] Modify `components/learn/BirdCard.tsx`. Add local state to track which clip set is active (`'songs' | 'calls'`) and the clip index, defaulting to `('songs', 0)`. Import `computeSpectrogram` from `core/spectrogram` and `Spectrogram` from `components/shared/Spectrogram`. Get `audioPlayer` from the Zustand store. Use `useMemo` to compute `SpectrogramData` from the active clip's `AudioBuffer` via `audioPlayer.getBuffer(clip.audio_url)` and `computeSpectrogram()` — if the buffer isn't loaded yet, pass empty data. Subscribe to `audioPlayer.onStateChange()` in a `useEffect` to detect when the active URL changes (via `getActiveUrl()`), and update the active clip type/index to match. Subscribe to `audioPlayer.onProgress()` in a `useEffect` to drive `currentTime` state for the playhead. Derive `isPlaying` from whether `getActiveUrl()` matches the active clip's URL. Wire `onSeek`: if audio is currently playing, call `audioPlayer.seek(time)`; if stopped, call `audioPlayer.play(activeClipUrl, time)`. Place the `<Spectrogram>` component in the JSX between the audio buttons `<div>` and the mnemonic `<p>`, giving it full card width and the spectrogram data, currentTime, duration, isPlaying, and onSeek props.
+
+---
+
+#### 5.2. Verify spectrogram layout on mobile devices
+
+**Type**: REVIEW
+**Output**: HITL approval of sizing, contrast, and tap accuracy
+**Depends on**: 5.1
+
+- [ ] Run the dev server (`cd beakspeak && npm run dev`) and open on a real mobile device or browser device emulator at ~375px width. Verify: spectrogram is ~80px tall and visually shows frequency banding for bird songs. Verify: theme colors render correctly (brown gradient on cream background). Verify: tapping a position on the spectrogram accurately seeks to that time (tap target is not too small). Verify: playhead animates smoothly during playback. Verify: switching between "Play Song" and "Play Call" updates the spectrogram. If adjustments are needed, iterate on height, colors, or padding before approving.
+
+---
+
+## Issue 6: Content pipeline — commercial license preference + quality filters
+
+**Type**: AFK
+**Blocked by**: None — can start immediately
+
+### Parent PRD
+
+`rpi/plans/audio-improvements-prd-2026-04-15.md`
+
+### What to build
+
+Update `populate_content.py` to prefer commercially-licensed recordings, hard-filter background species, and tighten length scoring, as described in the PRD's "Content Pipeline" implementation decisions.
+
+License tiering:
+- Replace `is_license_ok()` with two functions: `is_commercial_license(url)` (accepts CC-BY, CC-BY-SA, CC0 only) and `is_any_cc_license(url)` (accepts all current licenses — CC-BY, CC-BY-SA, CC-BY-NC, CC-BY-NC-SA, CC0, excluding ND).
+- First pass: filter recordings to commercial licenses only, then score and select.
+- Second pass: if fewer than 3 songs or 2 calls are found, relax to all CC licenses, log a warning to stdout naming the species and the shortfall, and continue selection.
+- Add `"commercial_ok": true/false` to each clip dict in the output.
+
+Background species filter:
+- After license filtering and before scoring, hard-filter any recording where the Xeno-canto `also` field is non-empty. This field lists background species audible in the recording. Extract it from the API response in `select_xc_clips()` or at the filtering stage.
+
+Tighter length scoring in `score_recording()`:
+- 5-15s: +3 (was +2 for 5-30s)
+- 15-30s: +1
+- 30-60s: -1 (was +1)
+- 60s+: -3 (was -1 for >120s)
+
+Summary report:
+- After processing all species, print a summary to stdout listing: species that fell back to NC licenses (with counts), species with fewer clips than target, total commercial vs NC clip counts.
+
+Update the manifest header `license_filter` field to describe the tiered approach.
+
+### How to verify
+
+- **Manual**: Run `uv run python3 populate_content.py` with `XC_API_KEY` set. Review:
+  1. Console output shows license pass (commercial first, fallback where needed).
+  2. Summary report at the end lists any NC fallbacks.
+  3. Output JSON has `"commercial_ok"` field on every audio clip.
+  4. No clips have background species in their source data (verify a sample by checking the `also` field on xeno-canto.org for selected clip IDs).
+  5. Selected clips trend shorter than before (compare lengths against current manifest).
+
+### Acceptance criteria
+
+- [ ] Given a species with sufficient commercial-licensed A/B recordings, when the pipeline runs, then all selected clips have `"commercial_ok": true`
+- [ ] Given a species with insufficient commercial-licensed recordings, when the pipeline runs, then it falls back to NC licenses, logs a warning naming the species, and flags those clips with `"commercial_ok": false`
+- [ ] Given a recording with a non-empty `also` field, when filtering runs, then that recording is excluded from selection
+- [ ] Given a 10-second recording and a 45-second recording of equal quality and region, when scoring runs, then the 10-second recording scores higher
+- [ ] Given the pipeline completes, when the summary report prints, then it lists all species with NC fallbacks and total commercial vs NC counts
+- [ ] Given the pipeline completes, when the output JSON is inspected, then every audio clip has a `"commercial_ok"` boolean field
+
+### User stories addressed
+
+- User story 10: Clips contain only the target bird species
+- User story 12: Short, focused clips (5-15 seconds)
+- User story 13: Pipeline prefers commercially-licensed recordings
+- User story 14: Clear warning on NC license fallback
+- User story 15: Each clip flagged with `commercial_ok`
+- User story 16: Summary report listing NC fallback species
+
+### Tasks
+
+#### 6.1. Implement two-pass license selection with commercial_ok flag
+
+**Type**: WRITE
+**Output**: Pipeline prefers commercial licenses, falls back with warning, flags each clip
+**Depends on**: none
+
+- [ ] Modify `populate_content.py`. Replace `is_license_ok(lic_url)` with two functions: `is_commercial_license(lic_url)` accepts only CC-BY, CC-BY-SA, and CC0 (checks for `creativecommons.org/licenses/by` without `-nc` present, and `publicdomain/zero`); `is_any_cc_license(lic_url)` accepts the same set as the old function (CC-BY, CC-BY-SA, CC-BY-NC, CC-BY-NC-SA, CC0 — no `-nd`). In `process_species()`, restructure the clip selection: first filter recordings to commercial licenses only, then apply quality and scoring to select clips. If fewer than 3 songs or 2 calls are found, print a warning to stdout naming the species and shortfall (e.g., `"  ⚠ AMRO: only 1 commercial song found, relaxing to NC licenses"`), relax to `is_any_cc_license`, and re-select. Add `"commercial_ok": True/False` to each clip dict based on which license pass selected it. Update the manifest header `license_filter` to read `"Prefer CC-BY, CC-BY-SA, CC0 (commercial OK); fallback to CC-BY-NC, CC-BY-NC-SA if needed"`. Also add `commercial_ok?: boolean` to the `AudioClip` interface in `core/types.ts` for TypeScript completeness.
+
+---
+
+#### 6.2. Add background species filter and tighter length scoring
+
+**Type**: WRITE
+**Output**: Recordings with background species excluded, shorter clips strongly preferred
+**Depends on**: none
+
+- [ ] Modify `populate_content.py`. The Xeno-canto API returns an `also` field (a string listing background species, e.g., `"Steller's Jay, Dark-eyed Junco"` or empty string `""`). This field is already present in the API response but not currently extracted. After license filtering and before scoring, add a hard-filter step: exclude any recording where `rec.get("also", "").strip()` is non-empty. Log the count of excluded recordings (e.g., `"  [Xeno-canto] Excluded N recordings with background species"`). Update `score_recording()` length brackets: 5-15s → +3 (was +2 for 5-30s), 15-30s → +1, 30-60s → -1 (was +1), 60s+ → -3 (was -1 for >120s). Parse the length string the same way as current code (`"M:SS"` format).
+
+---
+
+#### 6.3. Add summary report to pipeline output
+
+**Type**: WRITE
+**Output**: Summary report prints to stdout after pipeline completes
+**Depends on**: 6.1, 6.2
+
+- [ ] Modify `populate_content.py`. After the main loop that processes all species, collect and print a formatted summary report to stdout. Track these during processing (accumulate in lists/counters): species that fell back to NC licenses (species name + count of NC clips), species with fewer clips than target (species name + actual song/call counts vs 3/2 target), total commercial clips, total NC clips, total clips overall. Print the report with clear section headers, e.g., `"═══ PIPELINE SUMMARY ═══"`, a table or list of NC fallback species, a table of under-target species, and a totals line like `"Commercial: 58/75 clips (77%), NC fallback: 17/75 clips (23%)"`.
+
+---
+
+## Issue 7: Content pipeline — smart trimming
+
+**Type**: AFK
+**Blocked by**: None — can start immediately
+
+### Parent PRD
+
+`rpi/plans/audio-improvements-prd-2026-04-15.md`
+
+### What to build
+
+Update `download_media.py` to find the best active audio segment before trimming, as described in the PRD's "Content Pipeline: Smart Trimming" section.
+
+Currently, `normalize_audio()` trims blindly to the first 20 seconds via `-t 20`. Replace this with a two-step process:
+
+1. **Detect silence**: Run ffmpeg's `silencedetect` filter on the raw download to identify silent gaps (e.g., silence threshold of -30dB, minimum duration 0.5s). Parse the output to get a list of silence start/end timestamps.
+2. **Find best segment**: From the non-silent segments, select the first contiguous active region of at least 5 seconds. If the region is longer than 20 seconds, trim to the first 20 seconds of that region. The trim window should start slightly before the active region onset (~0.5s padding) so the vocalization doesn't feel abruptly cut.
+3. **Trim and normalize**: Pass the computed start time and duration to ffmpeg (via `-ss` and `-t` flags) along with the existing loudnorm and encoding pipeline.
+4. **Fallback**: If `silencedetect` fails, finds no silence boundaries, or the entire clip is active, fall back to the current behavior (first 20 seconds).
+
+### How to verify
+
+- **Manual**: Run the pipeline on a few species. Compare the output clips to the raw downloads:
+  1. For a raw clip that starts with 5 seconds of silence followed by a bird call, verify the output starts at the call (not the silence).
+  2. For a raw clip with a bird vocalization in the middle surrounded by silence, verify the output captures the vocalization.
+  3. For a short clip (< 20s) with no silence, verify the output is identical to current behavior.
+  4. Listen to 5-10 output clips and confirm they start with the target vocalization.
+
+### Acceptance criteria
+
+- [ ] Given a raw audio file with 3 seconds of silence followed by a vocalization, when smart trimming runs, then the output starts at approximately the vocalization onset (not at 0:00)
+- [ ] Given a raw audio file with no silent gaps, when smart trimming runs, then the output is the first 20 seconds (fallback behavior)
+- [ ] Given a raw audio file where `silencedetect` fails, when smart trimming runs, then the output is the first 20 seconds (fallback behavior) and a warning is logged
+- [ ] Given a raw audio file with a 7-second vocalization starting at second 10, when smart trimming runs, then the output contains the full vocalization
+- [ ] Output audio files are still normalized (loudnorm), encoded as OGG Opus 96kbps, and ≤20 seconds
+
+### User stories addressed
+
+- User story 11: Audio clips start with the target vocalization, not silence or noise
+
+### Tasks
+
+#### 7.1. Implement smart trimming with silencedetect
+
+**Type**: WRITE
+**Output**: Clips start at best active segment; fallback to first 20s on failure
+**Depends on**: none
+
+- [ ] Modify `download_media.py`. Add a new function `detect_best_segment(input_path: Path) -> tuple[float, float] | None` that runs ffmpeg with `-af silencedetect=noise=-30dB:d=0.5` on the input file and parses stderr for `silence_start` and `silence_end` timestamps. From those, compute non-silent segments (gaps between silence regions, plus the region before first silence and after last silence). Select the first non-silent segment that is at least 5 seconds long. Return `(start, duration)` where `start` is ~0.5s before the segment onset (clamped to 0) and `duration` is min(segment length + 0.5s padding, 20s). Return `None` if silencedetect fails (non-zero exit), finds no silence boundaries, or no segment meets the 5s minimum. Modify `normalize_audio()`: before running the loudnorm/encode pipeline, call `detect_best_segment()` on the input file. If it returns a segment, replace the existing `-t 20` with `-ss {start} -t {duration}` in the ffmpeg args. If it returns `None`, keep the existing `-t 20` behavior. Log which trimming mode was used (e.g., `"  Smart trim: 3.2s-18.2s"` or `"  Default trim: 0-20s"`).
+
+---
+
+## Issue 8: Re-run content pipeline with improved settings
+
+**Type**: HITL (review summary report, listen to output clips, verify quality improvement)
+**Blocked by**: Issues 6, 7
+
+### Parent PRD
+
+`rpi/plans/audio-improvements-prd-2026-04-15.md`
+
+### What to build
+
+Run the updated content pipeline end-to-end to produce improved audio clips for all 15 species. This is not a code change — it's a pipeline execution and quality review.
+
+Steps:
+1. Delete existing downloaded audio to force re-selection (or selectively delete clips that should be re-evaluated). Keep photos as-is.
+2. Run `uv run python3 populate_content.py` to re-score and re-select clips with the new license tiering, background species filter, and length scoring.
+3. Review the summary report. Note which species fell back to NC licenses and how many clips changed.
+4. Run `uv run python3 download_media.py` to download and normalize the newly-selected clips with smart trimming.
+5. Listen to a representative sample of output clips (at least 2 per species) and verify they are cleaner, shorter, and start with the target vocalization.
+6. Commit the updated manifest and any new/changed audio files.
+
+### How to verify
+
+- **Manual**:
+  1. Summary report shows the license breakdown (commercial vs NC per species).
+  2. Spot-check 5+ species on xeno-canto.org: verify selected clips have no background species listed.
+  3. Listen to 10+ clips across different species: they should be short, start with the bird's vocalization, and not contain obvious background birds.
+  4. Compare average clip length before vs after — should trend shorter.
+  5. The app loads and plays the new clips correctly.
+
+### Acceptance criteria
+
+- [ ] Given the updated pipeline has run, when the summary report is reviewed, then it shows how many clips are commercially licensed vs NC fallback
+- [ ] Given the new audio files are deployed, when a user plays clips in the app, then the audio plays correctly and the clips sound cleaner than before
+- [ ] Given the manifest is inspected, when `commercial_ok` fields are checked, then every audio clip has the field set
+- [ ] Given a spot-check of 5+ species, when the selected XC IDs are looked up on xeno-canto.org, then none have background species listed in the `also` field
+- [ ] The updated manifest and audio files are committed to the repository
+
+### User stories addressed
+
+- User story 10: Clips contain only the target bird species
+- User story 11: Clips start with the target vocalization
+- User story 12: Short, focused clips
+- User story 13: Pipeline prefers commercially-licensed recordings
+
+### Tasks
+
+#### 8.1. Clear existing audio and re-run content pipeline
+
+**Type**: CONFIG
+**Output**: New manifest and audio files generated with summary report
+**Depends on**: 6.3, 7.1
+
+- [ ] Delete existing audio files under `beakspeak/public/content/audio/` to force re-selection (keep `beakspeak/public/content/photos/` intact). Run `uv run python3 populate_content.py` to re-score and re-select clips with the new license tiering, background species filter, and length scoring. Save the summary report output. Then run `uv run python3 download_media.py` to download and normalize the newly-selected clips with smart trimming. Verify the pipeline completes without errors and the new `manifest.json` has `commercial_ok` fields on every clip.
+
+---
+
+#### 8.2. Review pipeline output and spot-check clips
+
+**Type**: REVIEW
+**Output**: HITL approval, commit updated manifest and audio files
+**Depends on**: 8.1
+
+- [ ] Review the summary report: check license breakdown (commercial vs NC per species), species with fewer clips than target. Spot-check at least 5 species on xeno-canto.org by looking up the selected XC IDs and verifying the `also` field is empty. Listen to at least 10 output clips across different species — they should be short, start with the bird's vocalization, and not contain obvious background birds. Compare average clip lengths against the previous manifest to confirm they trend shorter. Run `cd beakspeak && npm run dev` and verify the app loads and plays the new clips correctly. Once satisfied, commit the updated manifest and audio files.

--- a/rpi/plans/audio-improvements-prd-2026-04-15.md
+++ b/rpi/plans/audio-improvements-prd-2026-04-15.md
@@ -1,0 +1,199 @@
+# PRD: Audio Improvements — Spectrogram, Playback Fix, and Content Quality
+
+## Problem Statement
+
+BeakSpeak's audio experience has three gaps that hurt the learning experience:
+
+1. **Confusing playback state**: When a user rapidly taps "Play Song" then "Play Call" on a BirdCard, the underlying audio correctly stops and switches, but the button UI gets confused — both buttons may show as "playing" or "loading" because each tracks state independently via its own listener on a shared global player. Users can't tell which clip is actually playing.
+
+2. **No playback progress or visual feedback**: Audio clips play with no indication of progress, duration, or frequency content. Users can't see where they are in a clip, can't seek to a specific moment, and miss the learning opportunity of associating visual frequency patterns with bird vocalizations.
+
+3. **Noisy source clips**: Some Xeno-canto recordings contain multiple bird species in the background, are longer than necessary, or start with silence before the target vocalization. The content pipeline scores and selects clips but doesn't filter on background species, doesn't strongly penalize long clips, and trims blindly to the first 20 seconds regardless of where the target vocalization occurs. All current audio clips also use non-commercial (CC-BY-NC-SA) licenses, which limits future options.
+
+## Solution
+
+When this work is complete:
+
+- Only one audio clip plays at a time, and the UI always correctly reflects which clip is active. Switching between clips has a brief visual fade transition rather than an abrupt cut.
+- Every BirdCard displays an interactive spectrogram that shows the frequency structure of the current clip. The spectrogram is visible even when idle (showing the full clip shape), animates a playhead during playback, and is clickable to seek to any position. Users build visual-auditory associations as a natural part of the learning flow.
+- The content pipeline prefers commercially-licensed recordings, hard-filters clips with background species, favors shorter clips, and uses smart trimming to find the best segment of each recording. The manifest tracks which clips are commercially licensed. A summary report flags species that fell back to non-commercial licenses.
+
+## User Stories
+
+1. As a learner, I want only one audio clip playing at a time, so that I'm never confused by overlapping sounds.
+2. As a learner, I want the "Play Song" button to immediately show as idle when I tap "Play Call", so that I can tell which clip is active.
+3. As a learner, I want a brief visual fade when switching between clips, so that the transition feels intentional rather than jarring.
+4. As a learner, I want to see a spectrogram of the current clip on each BirdCard, so that I can associate visual frequency patterns with what I hear.
+5. As a learner, I want the spectrogram to show the full clip shape when no audio is playing, so that I can see the structure of the recording before I listen.
+6. As a learner, I want a playhead to animate across the spectrogram during playback, so that I know where I am in the clip.
+7. As a learner, I want to click any position on the spectrogram while audio is playing, so that I can jump to a specific moment I want to re-hear.
+8. As a learner, I want clicking the spectrogram when audio is stopped to seek to that position and start playing, so that the interaction is consistent regardless of playback state.
+9. As a learner, I want the spectrogram to update when I switch between "Play Song" and "Play Call", so that I see the visualization for whichever clip type I selected.
+10. As a learner, I want audio clips that contain only the target bird species, so that I'm not confused by background birds during training.
+11. As a learner, I want audio clips that start with the target vocalization (not silence or distant noise), so that every second of the clip is useful for learning.
+12. As a learner, I want short, focused clips (5-15 seconds), so that I can replay and study individual vocalizations quickly.
+13. As a content curator, I want the pipeline to prefer commercially-licensed recordings, so that I have flexibility for future distribution.
+14. As a content curator, I want a clear warning when the pipeline falls back to non-commercial licenses for a species, so that I know which species need attention.
+15. As a content curator, I want each clip in the manifest flagged with `commercial_ok: true/false`, so that I can track licensing status programmatically.
+16. As a content curator, I want a summary report after the pipeline runs listing all species that required non-commercial fallbacks, so that I have a single place to review licensing gaps.
+17. As a learner using a mobile device, I want the spectrogram to be large enough to see frequency patterns and tap accurately, so that the feature works on small screens.
+18. As a learner, I want the spectrogram colors to match the app's visual theme, so that the visualization feels integrated rather than bolted on.
+19. As a learner in a quiz, I want audio playback to continue working correctly (auto-play, replay buttons), so that quiz components are not broken by the audio system changes.
+20. As a learner swiping between BirdCards, I want audio to stop immediately on swipe, so that clips don't bleed between cards.
+
+## Implementation Decisions
+
+### Audio State Coordination
+
+The root cause of the UI bug is that each `AudioButton` subscribes to `onStateChange` independently, but the global `WebAudioPlayer` broadcasts all state transitions to all listeners without indicating which clip caused the transition. The fix is to track the active URL centrally in the player and expose it via `getActiveUrl()`. Each `AudioButton` compares the active URL against its own clip URLs to determine whether it should reflect the playing/loading state or show idle.
+
+### Spectrogram Computation
+
+The spectrogram is computed client-side from the decoded `AudioBuffer` already cached by the player. A windowed FFT (e.g., Hann window, 1024-sample frames) produces a 2D grid of time bins x frequency bins. This is computed once per clip when the buffer is first available and cached alongside it. No external libraries are needed — the FFT implementation is ~50 lines of pure TypeScript.
+
+### Spectrogram Rendering and Interaction
+
+The spectrogram renders on a `<canvas>` element placed on the BirdCard between the audio buttons and the mnemonic text. It is full card width and approximately 80px tall — large enough to see frequency banding and tap accurately on mobile, small enough not to dominate the card layout.
+
+The heatmap uses the app's existing theme colors (mapping magnitude to a gradient from background to primary color). A vertical playhead line animates across the canvas during playback via `requestAnimationFrame`.
+
+Click-to-seek behavior is consistent: clicking any position on the spectrogram computes the target time as `(clickX / canvasWidth) * duration`, seeks to that position, and starts playing. This is true whether audio is currently playing or stopped — the universal convention for clickable audio timelines.
+
+### Seeking via Web Audio API
+
+The Web Audio API's `AudioBufferSourceNode` does not support seeking on an existing source. To seek: stop the current source node, create a new one from the same buffer, and call `source.start(0, offsetInSeconds)`. This is handled internally by extending `play()` to accept an optional offset parameter.
+
+### Fade-Out on Stop
+
+When `stop()` is called (either explicitly or implicitly when `play()` is called for a new clip), the player applies a short gain ramp (~100ms) to zero before disconnecting the source. This prevents click artifacts and provides the brief fade transition when switching between clips. Implemented via `GainNode.gain.linearRampToValueAtTime()`.
+
+### Content Pipeline: License Tiering
+
+The `is_license_ok()` function is replaced with two-pass selection:
+- **Pass 1**: Filter for commercial-compatible licenses only (CC-BY, CC-BY-SA, CC0 — no `-NC` variants).
+- **Pass 2**: If fewer than 3 songs or 2 calls are found, relax to include CC-BY-NC and CC-BY-NC-SA (still excluding `-ND`), log a warning, and flag each fallback clip with `"commercial_ok": false`.
+
+Each clip in the manifest gets a `"commercial_ok"` boolean field. The manifest header's `license_filter` description is updated to reflect the tiered approach.
+
+### Content Pipeline: Background Species Filter
+
+Xeno-canto recordings include an `also` field listing background species audible in the recording. The pipeline hard-filters any recording where `also` is non-empty. This is applied before scoring, reducing the candidate pool to single-species recordings.
+
+### Content Pipeline: Tighter Length Scoring
+
+The scoring function is updated to more aggressively favor short clips:
+- 5-15s: +3 (was +2 for 5-30s)
+- 15-30s: +1
+- 30-60s: -1 (was +1)
+- 60s+: -3 (was -1 for >120s)
+
+### Content Pipeline: Smart Trimming
+
+Instead of blindly taking the first 20 seconds, `download_media.py` runs ffmpeg's `silencedetect` filter on the raw download to identify quiet gaps. It then selects the first non-silent segment of sufficient length (target: 5-15s of active audio) and trims around that window. If silence detection fails or finds nothing useful, the current behavior (first 20s) is the fallback.
+
+### Scope of UI Changes
+
+The spectrogram is added to `BirdCard` in the Learn flow only. Quiz components (`ThreeChoiceQuiz`, `SameDifferent`, `IntroQuiz`) use `audioPlayer.play()` directly and are unaffected by the spectrogram work. The AudioPlayer interface changes (offset parameter, getActiveUrl, getProgress, fade-out) are additive and backward-compatible — quiz components continue to work without modification.
+
+## Module Design
+
+### AudioPlayer (`adapters/audio.ts` — modify)
+
+- **Responsibility**: Single source of truth for all audio playback, state, and progress.
+- **Interface**:
+  - `play(url: string, offset?: number): Promise<void>` — stop current, play from optional offset
+  - `stop(): void` — fade out (~100ms) then disconnect
+  - `seek(time: number): void` — shortcut for `play(activeUrl, time)`
+  - `getActiveUrl(): string | null` — URL of the currently playing/loading clip
+  - `getProgress(): { currentTime: number; duration: number }` — elapsed and total time
+  - `onStateChange(cb): () => void` — existing, unchanged
+  - `onProgress(cb: (currentTime: number, duration: number) => void): () => void` — new, fires via `requestAnimationFrame` during playback
+  - `prefetch(url): void` — existing, unchanged
+  - `getBuffer(url: string): AudioBuffer | null` — expose cached buffer for spectrogram computation
+  - Failure modes: fetch errors and decode errors set state to `'error'`. Seeking on a null buffer is a no-op.
+- **Tested**: Yes
+
+### Spectrogram Renderer (`core/spectrogram.ts` — new)
+
+- **Responsibility**: Compute spectrogram data from an AudioBuffer. Pure computation, no DOM or React dependencies.
+- **Interface**:
+  - `computeSpectrogram(buffer: AudioBuffer, options?: { fftSize?: number; hopSize?: number }): SpectrogramData`
+  - `SpectrogramData`: `{ magnitudes: Float32Array[]; timeBins: number; frequencyBins: number; duration: number; sampleRate: number }`
+  - Each entry in `magnitudes` is one time slice; values are normalized 0-1 magnitude.
+  - Failure modes: returns empty data for zero-length buffers.
+- **Tested**: Yes — verify output shape, frequency peaks for known pure-tone inputs, silence produces near-zero magnitudes.
+
+### Spectrogram Component (`components/shared/Spectrogram.tsx` — new)
+
+- **Responsibility**: Render spectrogram heatmap to canvas, animate playhead, handle click-to-seek.
+- **Interface (props)**:
+  - `data: SpectrogramData` — precomputed spectrogram grid
+  - `currentTime: number` — elapsed playback time (drives playhead position)
+  - `duration: number` — total clip duration
+  - `isPlaying: boolean` — whether playback is active (controls playhead animation)
+  - `onSeek: (time: number) => void` — called when user clicks a position
+  - Failure modes: renders an empty/gray canvas if `data` has zero bins.
+- **Tested**: No — canvas rendering is tested indirectly through the Spectrogram Renderer module.
+
+### AudioButton (`components/shared/AudioButton.tsx` — modify)
+
+- **Responsibility**: Play/stop toggle for a specific set of clips.
+- **Interface**: Props unchanged. Internal change: replaces local `audioState` tracking with comparison of `audioPlayer.getActiveUrl()` against own clip URLs. Removes individual `onStateChange` subscription in favor of reading centralized state.
+- **Tested**: Covered by AudioPlayer tests for state coordination. No dedicated AudioButton tests needed.
+
+### BirdCard (`components/learn/BirdCard.tsx` — modify)
+
+- **Responsibility**: Display species info, audio controls, and shared spectrogram.
+- **Interface**: Props unchanged. Adds `Spectrogram` component between audio buttons and mnemonic text. Tracks which clip set (songs/calls) was last played to show the correct spectrogram. Defaults to first song clip's spectrogram when idle.
+- **Tested**: No.
+
+### Content Pipeline — populate_content.py (modify)
+
+- **Responsibility**: Fetch, filter, score, and select Xeno-canto recordings.
+- **Interface**: Input/output JSON files unchanged. Behavioral changes: two-pass license selection, `also` field hard-filter, tighter length scoring, `commercial_ok` flag per clip, summary report to stdout.
+- **Tested**: No — validated by inspection of output manifest and summary report.
+
+### Content Pipeline — download_media.py (modify)
+
+- **Responsibility**: Download, normalize, and trim audio clips.
+- **Interface**: Input/output unchanged. Behavioral change: smart trimming via `silencedetect` before the existing loudnorm/encode pipeline. Fallback to first-20s on detection failure.
+- **Tested**: No — validated by listening to output clips.
+
+## Testing Decisions
+
+Good tests for this feature verify external behavior, not implementation details:
+
+- **AudioPlayer state transitions**: play → loading → playing → idle; play while playing (stop-before-play guarantee); seek mid-playback; getActiveUrl reflects current clip; getProgress returns sensible values.
+- **Spectrogram computation**: known input (silence, pure sine wave, white noise) produces expected output shape and magnitude distribution. Edge case: zero-length buffer.
+- **State coordination**: when play is called with URL-A, then immediately with URL-B, getActiveUrl returns URL-B and state settles to 'playing' (not stuck in 'loading' from the first call).
+
+Reference tests in the codebase: `beakspeak/src/core/*.test.ts` — these follow the pattern of testing pure functions with known inputs and assertions on output shape/values.
+
+Quiz components (`ThreeChoiceQuiz`, `SameDifferent`, `IntroQuiz`) should continue to pass existing tests without modification, serving as regression coverage for the AudioPlayer interface changes.
+
+## Out of Scope
+
+- **Spectrogram in quiz components**: The spectrogram is added to BirdCard only. Quiz components have different UX patterns (auto-play, sequential playback, timed responses) and adding spectrograms there is a separate design decision.
+- **Pause/resume model**: The current play/stop model is retained. Pause would pair well with seeking but is a larger UX change that can be added later if needed.
+- **Spectrogram zoom or frequency labels**: The spectrogram is a learning aid and progress bar, not a scientific analysis tool. No axis labels, zoom, or frequency readouts.
+- **Confuser drill and clip-to-photo exercise types**: These were deferred in the sprint 0-2 plan and remain deferred.
+- **Photo licensing changes**: Only audio licensing is addressed. Wikipedia photos are already CC-BY-SA.
+- **Re-downloading all audio**: The pipeline re-run will re-score and may select different clips. Only newly-selected clips are downloaded; existing cached files are kept if still selected.
+
+## Open Questions
+
+1. **How sparse are commercial licenses for PNW birds on Xeno-canto?**
+   Owner: Content curator (user). Resolution: Run the updated pipeline and review the summary report. If commercial coverage is very low, consider expanding the region filter or accepting NC for the initial release.
+
+2. **Should the spectrogram be added to quiz feedback screens?**
+   Owner: Product (user). Resolution: Defer to post-launch feedback. If learners find the spectrogram valuable on BirdCards, consider adding it to the "correct answer" feedback in quizzes.
+
+3. **Is 80px tall sufficient for the spectrogram on small mobile screens?**
+   Owner: Design (user). Resolution: Implement at 80px and test on a few real devices. Adjust if needed — the component should be height-configurable via a prop.
+
+## Further Notes
+
+- The `prefetch()` method on `WebAudioPlayer` exists but is never called anywhere in the codebase. It could be used to pre-compute spectrograms for upcoming cards in the Learn flow, improving perceived performance. This is an optimization opportunity but not part of this PRD.
+- The Xeno-canto API provides pre-rendered sonogram images (`sono` field) for every recording. These are not used in this work but could serve as a fallback or comparison reference during development.
+- The content pipeline must be re-run after the scoring and filtering changes. This will likely change which clips are selected for some species. The download step only fetches newly-selected clips; it skips files that already exist locally.
+- Quiz components call `audioPlayer.play()` directly and don't use `AudioButton`. The AudioPlayer interface changes are additive (new optional parameter, new methods), so quiz components require no code changes.


### PR DESCRIPTION
## Summary
- **Issue 1**: Fix audio state coordination — track `activeUrl` centrally in `AudioPlayer`, derive display state in `AudioButton`, add `GainNode` routing with 100ms fade-out on stop to eliminate click/pop artifacts
- **Issue 2**: Add progress tracking (`getProgress`, `onProgress`), seeking (`seek`), play offset (`play(url, offset)`), and buffer access (`getBuffer`) to `AudioPlayer`
- **Issue 3**: Implement from-scratch FFT-based spectrogram computation engine (`core/spectrogram.ts`) — Hann window, radix-2 Cooley-Tukey FFT, magnitude normalization, zero DOM dependencies
- **Issue 4**: Create `Spectrogram.tsx` canvas component — heatmap rendering with theme colors, animated playhead, click-to-seek, `ResizeObserver` for responsive redraw

## Test plan
- [x] All 63 tests pass (`npx vitest run`)
- [ ] Manual: open BirdCard, tap Play Song then Play Call — only new button shows playing, brief fade on switch
- [ ] Manual: verify spectrogram renders heatmap, playhead animates during playback, click seeks
- [ ] Manual: verify on mobile viewport (~375px) — spectrogram visible and tappable

🤖 Generated with [Claude Code](https://claude.com/claude-code)