### PR TITLE
Fix and improve testing workflow; add non-guided path plan

### DIFF
--- a/.github/workflows/beakspeak-ci.yml
+++ b/.github/workflows/beakspeak-ci.yml
@@ -1,0 +1,55 @@
+name: BeakSpeak CI
+
+on:
+  pull_request:
+    paths:
+      - 'beakspeak/**'
+      - '.github/workflows/beakspeak-ci.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'beakspeak/**'
+      - '.github/workflows/beakspeak-ci.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: beakspeak
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: beakspeak/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Typecheck
+        run: npx tsc -p tsconfig.app.json --noEmit
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npx vitest run
+
+      - name: Mobile E2E
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: beakspeak/playwright-report
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,3 +175,19 @@ cd beakspeak && npx vitest run
 bash scripts/build-site.sh
 npx --prefix beakspeak wrangler deploy
 ```
+
+## Testing Guidance For Agents
+
+Use the lightest test layer that gives confidence for the change, and escalate only when the change reaches a full user-facing flow.
+
+- For most code changes in `beakspeak/src/`, run:
+  - `cd beakspeak && npm run typecheck`
+  - `cd beakspeak && npm run lint`
+  - relevant unit tests via `cd beakspeak && npm run test:unit`
+- Prefer targeted unit tests while iterating when you know the affected area. Run the full unit suite before finishing if the change touches shared logic, state management, quiz building, lesson flow, or reused components.
+- Run mobile E2E with `cd beakspeak && npm run test:e2e` only after a user-facing flow is complete enough to exercise end-to-end. Do not run E2E after every small edit.
+- Run E2E earlier than end-of-feature if the task is specifically about browser behavior, interaction bugs, responsive/mobile layout, persistence, navigation, or fixing a previously observed runtime issue.
+- Do not run `cd beakspeak && npm run test:ci` by default. That command is a convenience mirror of CI, but the full CI stack is intended to run in GitHub Actions. Run it locally only if the user explicitly asks for it or if you are debugging CI-specific behavior.
+- For docs-only, content-only, or clearly isolated non-runtime changes, it is acceptable to skip some layers if they are irrelevant. State explicitly what you did and did not run.
+- When adding or modifying Playwright tests, make sure the changed spec passes locally before finishing.
+- Treat browser console errors surfaced by the E2E fixture as real regressions unless there is a documented reason to ignore them.

--- a/README.md
+++ b/README.md
@@ -87,14 +87,115 @@ uv run download_media.py
 
 Audio and photos are gitignored; `manifest.json` and `tier1_seattle_birds_populated.json` are checked in.
 
-## Running tests
+## Testing
+
+BeakSpeak has four practical validation layers:
+
+- **Type checking** with `tsc`
+- **Linting** with `eslint`
+- **Unit tests** with `vitest`
+- **Mobile end-to-end tests** with Playwright
+
+GitHub Actions runs the same checks in automation, but `test:ci` is mainly a CI mirror and is not the default local workflow.
+
+### Install test tooling
 
 ```bash
 cd beakspeak
-npx vitest run        # 71 unit tests across core modules
+npm install
+npx playwright install chromium
 ```
 
-Tests cover: manifest loading, lesson gating/progression, FSRS rating logic, quiz session building.
+### Type checking
+
+```bash
+cd beakspeak
+npm run typecheck
+```
+
+### Linting
+
+```bash
+cd beakspeak
+npm run lint
+```
+
+### Unit tests
+
+```bash
+cd beakspeak
+npm run test:unit
+```
+
+`npm run test:unit` is the same Vitest suite as `npx vitest run`.
+
+Current unit coverage includes manifest loading, lesson gating/progression, FSRS scheduling, quiz session building, audio adapter behavior, and component-level interactions.
+
+### Mobile end-to-end test
+
+```bash
+cd beakspeak
+npm run test:e2e
+```
+
+Run this after the flow is implemented and you want browser-level confirmation that the mobile path still works.
+
+The Playwright suite runs at a mobile viewport and currently covers:
+
+- resetting progress to a clean state
+- completing Lesson 1
+- finishing the intro quiz
+- verifying progress persistence
+- starting the review flow
+
+Reusable E2E helpers live in `beakspeak/e2e/fixtures.ts` so future browser tests can compose app flows cleanly.
+
+### Manual testing
+
+If you want to sanity-check the app yourself, the usual sequence is:
+
+```bash
+cd beakspeak
+npm run dev
+```
+
+Then verify the main mobile flows in the browser:
+
+- open the Learn tab
+- complete Lesson 1
+- finish the intro quiz
+- check that progress persists after a reload
+- open the Progress tab and start a review session
+
+### Full local CI-equivalent run
+
+```bash
+cd beakspeak
+npm run test:ci
+```
+
+This runs:
+
+- `npm run typecheck`
+- `npm run lint`
+- `npm run test:unit`
+- `npm run test:e2e`
+
+Use this only when you explicitly want the full local mirror of CI.
+
+### Continuous integration
+
+GitHub Actions workflow: `.github/workflows/beakspeak-ci.yml`
+
+CI currently performs:
+
+- dependency install
+- Playwright Chromium install
+- typecheck
+- lint
+- Vitest
+- mobile Playwright E2E
+- Playwright report artifact upload when present
 
 ## Deploying
 

--- a/beakspeak/e2e/fixtures.ts
+++ b/beakspeak/e2e/fixtures.ts
@@ -1,0 +1,100 @@
+import { expect, test as base, type Page } from '@playwright/test'
+
+class BeakSpeakApp {
+  constructor(private readonly page: Page) {}
+
+  async gotoHome() {
+    await this.page.goto('/beakspeak/')
+    await expect(this.page.getByRole('heading', { name: 'Learn Birds' })).toBeVisible()
+  }
+
+  async resetProgress() {
+    await this.gotoHome()
+    await this.page.getByRole('button', { name: /Progress/ }).click()
+    await expect(this.page.getByRole('heading', { name: 'Progress' })).toBeVisible()
+
+    await this.page.getByRole('button', { name: 'Reset All Progress' }).click()
+    await this.page.getByRole('button', { name: 'Yes, Reset' }).click()
+
+    await expect(this.page.getByText('0', { exact: true }).first()).toBeVisible()
+    await expect(this.page.getByText('Due Now')).toBeVisible()
+  }
+
+  async answerIntroQuiz(questionCount = 5) {
+    for (let question = 1; question <= questionCount; question += 1) {
+      await expect(this.page.getByText(`Question ${question} of ${questionCount}`)).toBeVisible()
+
+      const choiceButtons = this.page.locator('button').filter({ has: this.page.locator('img') })
+      await expect(choiceButtons).toHaveCount(3)
+      await choiceButtons.first().click()
+
+      // Correct answers auto-advance after 1.5s; incorrect answers show a Next button.
+      await this.page.waitForTimeout(1800)
+
+      const nextButton = this.page.getByRole('button', { name: 'Next' })
+      if (await nextButton.isVisible()) {
+        await nextButton.click()
+      }
+    }
+  }
+
+  async completeLessonOne() {
+    await this.gotoHome()
+    await expect(this.page.getByText('0 of 15 birds learned')).toBeVisible()
+
+    await this.page.getByRole('button', { name: /Lesson 1: The unmistakable three/i }).click()
+
+    await expect(this.page.getByRole('heading', { name: 'American Crow' })).toBeVisible()
+    await this.page.getByRole('button', { name: /Next/i }).click()
+
+    await expect(this.page.getByRole('heading', { name: "Steller's Jay" })).toBeVisible()
+    await this.page.getByRole('button', { name: /Next/i }).click()
+
+    await expect(this.page.getByRole('heading', { name: 'Northern Flicker' })).toBeVisible()
+    await this.page.getByRole('button', { name: /Start Quiz/i }).click()
+
+    await expect(this.page.getByText('Question 1 of 5')).toBeVisible()
+    await this.answerIntroQuiz()
+
+    await expect(this.page.getByRole('heading', { name: 'Lesson Complete!' })).toBeVisible()
+    await this.page.getByRole('button', { name: 'Continue' }).click()
+
+    await expect(this.page.getByRole('heading', { name: 'Learn Birds' })).toBeVisible()
+    await expect(this.page.getByText('3 of 15 birds learned')).toBeVisible()
+    await expect(this.page.getByRole('button', { name: /Lesson 2: Backyard singers/i })).toBeEnabled()
+  }
+
+  async startReviewFromProgress() {
+    await this.page.getByRole('button', { name: /Progress/ }).click()
+    await expect(this.page.getByRole('heading', { name: 'Progress' })).toBeVisible()
+    await expect(this.page.getByRole('button', { name: /Start Review \(3 due\)/i })).toBeVisible()
+
+    await this.page.getByRole('button', { name: /Start Review \(3 due\)/i }).click()
+    await expect(this.page.getByRole('heading', { name: 'Quiz' })).toBeVisible()
+
+    await this.page.getByRole('button', { name: 'Start Review' }).click()
+    await expect(this.page.getByRole('button', { name: /← Quit/i })).toBeVisible()
+    await expect(this.page.getByText('1 / 3')).toBeVisible()
+    await expect(this.page.locator('button').filter({ has: this.page.locator('img') })).toHaveCount(3)
+  }
+}
+
+export const test = base.extend<{ app: BeakSpeakApp }>({
+  app: async ({ page }, runFixture) => {
+    const consoleErrors: string[] = []
+    page.on('console', message => {
+      if (message.type() === 'error') {
+        consoleErrors.push(message.text())
+      }
+    })
+    page.on('pageerror', error => {
+      consoleErrors.push(error.message)
+    })
+
+    await runFixture(new BeakSpeakApp(page))
+
+    expect(consoleErrors).toEqual([])
+  },
+})
+
+export { expect }

--- a/beakspeak/e2e/mobile-learn-review.spec.ts
+++ b/beakspeak/e2e/mobile-learn-review.spec.ts
@@ -1,0 +1,7 @@
+import { test } from './fixtures'
+
+test('mobile lesson 1 flow completes and starts review', async ({ app }) => {
+  await app.resetProgress()
+  await app.completeLessonOne()
+  await app.startReviewFromProgress()
+})

--- a/beakspeak/eslint.config.js
+++ b/beakspeak/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'playwright-report', 'test-results']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/beakspeak/package-lock.json
+++ b/beakspeak/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.2.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1939,6 +1940,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -4935,6 +4952,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/beakspeak/package.json
+++ b/beakspeak/package.json
@@ -7,7 +7,11 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc -p tsconfig.app.json --noEmit",
+    "test:unit": "vitest run",
+    "test:e2e": "playwright test",
+    "test:ci": "npm run typecheck && npm run lint && npm run test:unit && npm run test:e2e"
   },
   "dependencies": {
     "dexie": "^4.4.2",
@@ -19,6 +23,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.2.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/beakspeak/playwright.config.ts
+++ b/beakspeak/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+    viewport: { width: 390, height: 844 },
+    isMobile: true,
+    hasTouch: true,
+  },
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 4173',
+    url: 'http://127.0.0.1:4173/beakspeak/',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+})

--- a/beakspeak/src/adapters/audio.test.ts
+++ b/beakspeak/src/adapters/audio.test.ts
@@ -139,9 +139,9 @@ describe('WebAudioPlayer', () => {
     })
 
     it('tracks the requested URL while a clip is loading', async () => {
-      let resolveFetch: ((value: Response | PromiseLike<Response>) => void) | null = null
+      let resolveFetch!: (value: Response | PromiseLike<Response>) => void
       vi.stubGlobal('fetch', vi.fn(() => new Promise(resolve => {
-        resolveFetch = resolve as (value: Response | PromiseLike<Response>) => void
+        resolveFetch = resolve as typeof resolveFetch
       })))
 
       const player = new WebAudioPlayer()
@@ -150,7 +150,7 @@ describe('WebAudioPlayer', () => {
       expect(player.getState()).toBe('loading')
       expect(player.getActiveUrl()).toBe('https://example.com/song.ogg')
 
-      resolveFetch?.({
+      resolveFetch({
         ok: true,
         arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
       } as Response)
@@ -195,9 +195,9 @@ describe('WebAudioPlayer', () => {
     })
 
     it('does not restart playback after stop() cancels an in-flight play()', async () => {
-      let resolveFetch: ((value: Response | PromiseLike<Response>) => void) | null = null
+      let resolveFetch!: (value: Response | PromiseLike<Response>) => void
       vi.stubGlobal('fetch', vi.fn(() => new Promise(resolve => {
-        resolveFetch = resolve as (value: Response | PromiseLike<Response>) => void
+        resolveFetch = resolve as typeof resolveFetch
       })))
 
       const player = new WebAudioPlayer()
@@ -208,7 +208,7 @@ describe('WebAudioPlayer', () => {
       expect(player.getState()).toBe('loading')
 
       player.stop()
-      resolveFetch?.({
+      resolveFetch({
         ok: true,
         arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
       } as Response)

--- a/beakspeak/src/components/learn/BirdCard.tsx
+++ b/beakspeak/src/components/learn/BirdCard.tsx
@@ -21,11 +21,25 @@ export default function BirdCard({ species }: Props) {
   const [activeClipType, setActiveClipType] = useState<'songs' | 'calls'>('songs')
   const [activeClipIndex, setActiveClipIndex] = useState(0)
   const [currentTime, setCurrentTime] = useState(0)
-  const [, setSpectrogramRevision] = useState(0)
 
   const activeClips = species.audio_clips[activeClipType]
   const activeClip = activeClips[activeClipIndex] ?? activeClips[0]
   const activeClipUrl = activeClip?.audio_url ?? null
+
+  const [spectrogramCache, setSpectrogramCache] = useState(() => {
+    const initialCache = new Map<string, SpectrogramData>()
+    if (!activeClipUrl) return initialCache
+
+    const buffer = audioPlayer.getBuffer(activeClipUrl)
+    if (!buffer) return initialCache
+
+    initialCache.set(activeClipUrl, computeSpectrogram(buffer))
+    return initialCache
+  })
+  const spectrogramCacheRef = useRef(spectrogramCache)
+  useEffect(() => {
+    spectrogramCacheRef.current = spectrogramCache
+  }, [spectrogramCache])
 
   const activeUrl = audioPlayer.getActiveUrl()
   const isPlaying = activeUrl != null && activeUrl === activeClipUrl
@@ -36,25 +50,25 @@ export default function BirdCard({ species }: Props) {
     activeClipUrlRef.current = activeClipUrl
   }, [activeClipUrl])
 
-  // Cache of pre-computed spectrogram data keyed by clip URL
-  const spectrogramCache = useRef(new Map<string, SpectrogramData>())
-
   const cacheSpectrogramForUrl = useCallback((url: string | null, buffer?: AudioBuffer | null) => {
-    if (!url) return null
-    const cached = spectrogramCache.current.get(url)
-    if (cached) return cached
+    if (!url) return
+    if (spectrogramCacheRef.current.has(url)) return
 
-    const resolvedBuffer = buffer ?? audioPlayer.getBuffer(url)
-    if (!resolvedBuffer) return null
+    const resolvedBuffer = buffer === undefined ? audioPlayer.getBuffer(url) : buffer
+    if (!resolvedBuffer) return
 
-    const data = computeSpectrogram(resolvedBuffer)
-    spectrogramCache.current.set(url, data)
-    return data
+    setSpectrogramCache(prev => {
+      if (prev.has(url)) return prev
+
+      const next = new Map(prev)
+      next.set(url, computeSpectrogram(resolvedBuffer))
+      return next
+    })
   }, [audioPlayer])
 
   const spectrogramData = activeClipUrl == null
     ? EMPTY_SPECTROGRAM
-    : cacheSpectrogramForUrl(activeClipUrl) ?? EMPTY_SPECTROGRAM
+    : spectrogramCache.get(activeClipUrl) ?? EMPTY_SPECTROGRAM
   const duration = spectrogramData.duration
 
   // Prefetch ALL clips on mount and pre-compute spectrograms as buffers settle
@@ -69,12 +83,7 @@ export default function BirdCard({ species }: Props) {
     for (const url of allUrls) {
       void audioPlayer.prefetch(url).then(buffer => {
         if (cancelled) return
-        const data = cacheSpectrogramForUrl(url, buffer)
-        if (!data) return
-
-        if (url === activeClipUrlRef.current) {
-          setSpectrogramRevision(prev => prev + 1)
-        }
+        cacheSpectrogramForUrl(url, buffer)
       })
     }
 
@@ -94,18 +103,14 @@ export default function BirdCard({ species }: Props) {
       if (songIdx >= 0) {
         setActiveClipType('songs')
         setActiveClipIndex(songIdx)
-        if (cacheSpectrogramForUrl(url) && url === activeClipUrlRef.current) {
-          setSpectrogramRevision(prev => prev + 1)
-        }
+        cacheSpectrogramForUrl(url)
         return
       }
       const callIdx = species.audio_clips.calls.findIndex(c => c.audio_url === url)
       if (callIdx >= 0) {
         setActiveClipType('calls')
         setActiveClipIndex(callIdx)
-        if (cacheSpectrogramForUrl(url) && url === activeClipUrlRef.current) {
-          setSpectrogramRevision(prev => prev + 1)
-        }
+        cacheSpectrogramForUrl(url)
       }
     })
     return unsub
@@ -116,10 +121,7 @@ export default function BirdCard({ species }: Props) {
     const unsub = audioPlayer.onProgress((time) => {
       setCurrentTime(time)
     })
-    return () => {
-      unsub()
-      setCurrentTime(0)
-    }
+    return unsub
   }, [audioPlayer])
 
   // Stop playback when the card unmounts (e.g. ← Back button bypasses swipe handlers)

--- a/beakspeak/src/components/learn/IntroQuiz.tsx
+++ b/beakspeak/src/components/learn/IntroQuiz.tsx
@@ -30,6 +30,16 @@ export default function IntroQuiz({ items, onComplete }: Props) {
     return () => { audioPlayer.stop() }
   }, [audioPlayer])
 
+  const advance = useCallback(() => {
+    if (currentIndex + 1 >= items.length) {
+      onComplete([...results])
+      return
+    }
+    setCurrentIndex(prev => prev + 1)
+    setSelectedId(null)
+    setShowingResult(false)
+  }, [currentIndex, items.length, onComplete, results])
+
   const handleSelect = useCallback((speciesId: string) => {
     if (showingResult || !current) return
 
@@ -42,17 +52,7 @@ export default function IntroQuiz({ items, onComplete }: Props) {
       // Auto-advance after 1.5s for correct answers
       setTimeout(() => advance(), 1500)
     }
-  }, [showingResult, current])
-
-  const advance = useCallback(() => {
-    if (currentIndex + 1 >= items.length) {
-      onComplete([...results])
-      return
-    }
-    setCurrentIndex(prev => prev + 1)
-    setSelectedId(null)
-    setShowingResult(false)
-  }, [currentIndex, items.length, onComplete, results])
+  }, [advance, showingResult, current])
 
   const feedbackRef = useRef<HTMLDivElement>(null)
   const isCorrect = !current || selectedId === current.targetSpecies.id

--- a/beakspeak/src/components/learn/LearnSession.tsx
+++ b/beakspeak/src/components/learn/LearnSession.tsx
@@ -25,10 +25,7 @@ export default function LearnSession({ lesson, onComplete }: Props) {
   const [phase, setPhase] = useState<Phase>(hasReviewPhase ? 'review' : 'cards')
   const [cardIndex, setCardIndex] = useState(0)
   const [swipeDirection, setSwipeDirection] = useState<'left' | 'right' | null>(null)
-
-  if (!manifest) return null
-
-  const lessonSpecies = getSpeciesByIds(manifest, lesson.species)
+  const lessonSpecies = manifest ? getSpeciesByIds(manifest, lesson.species) : []
 
   const handleSwipeRight = useCallback(() => {
     if (cardIndex < lessonSpecies.length - 1) {
@@ -55,6 +52,8 @@ export default function LearnSession({ lesson, onComplete }: Props) {
   const handleReviewComplete = useCallback(() => {
     setPhase('cards')
   }, [])
+
+  if (!manifest) return null
 
   // Phase: forward testing review
   if (phase === 'review') {
@@ -153,7 +152,7 @@ export default function LearnSession({ lesson, onComplete }: Props) {
 
   // Phase: intro quiz
   if (phase === 'quiz') {
-    const quizItems = buildIntroQuiz(lesson, lessonSpecies, introducedSpecies, manifest.species)
+    const quizItems = buildIntroQuiz(lessonSpecies, introducedSpecies)
     return (
       <div className="flex flex-col h-full">
         <div className="p-4 bg-primary/10 text-center">

--- a/beakspeak/src/components/quiz/QuizResult.tsx
+++ b/beakspeak/src/components/quiz/QuizResult.tsx
@@ -38,9 +38,9 @@ export default function QuizResult({ answers, onDone }: Props) {
             Needs More Practice
           </h3>
           <div className="space-y-2">
-            {needsPractice.map(a => (
+            {needsPractice.map((a, index) => (
               <div
-                key={a.species.id}
+                key={`${a.species.id}-${index}`}
                 className="flex items-center gap-3 p-3 bg-error/5 border border-error/20 rounded-xl"
               >
                 <img

--- a/beakspeak/src/components/quiz/ThreeChoiceQuiz.tsx
+++ b/beakspeak/src/components/quiz/ThreeChoiceQuiz.tsx
@@ -12,7 +12,7 @@ export default function ThreeChoiceQuiz({ item, onAnswer }: Props) {
   const audioPlayer = useAppStore(s => s.audioPlayer)
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [showingResult, setShowingResult] = useState(false)
-  const startTime = useRef(Date.now())
+  const startTime = useRef(0)
   const playState = useAudioStateForUrl(audioPlayer, item.clip.audio_url)
 
   // Auto-play clip on mount

--- a/beakspeak/src/components/shared/AudioButton.tsx
+++ b/beakspeak/src/components/shared/AudioButton.tsx
@@ -23,13 +23,12 @@ export default function AudioButton({ clips, label, speciesId, variant = 'primar
     return idx >= 0 ? (idx + 1) % clips.length : 0
   })
 
-  const clipUrls = clips.map(c => c.audio_url)
-
   // Subscribe to player state and derive display state from activeUrl
   useEffect(() => {
+    const clipUrlSet = new Set(clips.map(clip => clip.audio_url))
     const unsub = audioPlayer.onStateChange((state: AudioState) => {
       const activeUrl = audioPlayer.getActiveUrl()
-      if (activeUrl && clipUrls.includes(activeUrl)) {
+      if (activeUrl && clipUrlSet.has(activeUrl)) {
         setDisplayState(state)
         if (state === 'idle') {
           setClipIndex(prev => (prev + 1) % clips.length)
@@ -39,21 +38,22 @@ export default function AudioButton({ clips, label, speciesId, variant = 'primar
       }
     })
     return unsub
-  }, [audioPlayer, clipUrls.join(','), clips.length])
+  }, [audioPlayer, clips])
 
   const currentClip = clips[clipIndex]
-  if (!currentClip) return null
 
   const handlePlay = useCallback(async () => {
+    if (!currentClip) return
     if (displayState === 'playing') {
       audioPlayer.stop()
       return
     }
 
-    const clip = clips[clipIndex]
-    setLastPlayedClip(speciesId, clip.xc_id)
-    await audioPlayer.play(clip.audio_url)
-  }, [audioPlayer, clips, clipIndex, speciesId, setLastPlayedClip, displayState])
+    setLastPlayedClip(speciesId, currentClip.xc_id)
+    await audioPlayer.play(currentClip.audio_url)
+  }, [audioPlayer, currentClip, speciesId, setLastPlayedClip, displayState])
+
+  if (!currentClip) return null
 
   const isPrimary = variant === 'primary'
 

--- a/beakspeak/src/core/fsrs.ts
+++ b/beakspeak/src/core/fsrs.ts
@@ -1,4 +1,4 @@
-import { createEmptyCard, fsrs, generatorParameters, Rating, type Card } from 'ts-fsrs'
+import { createEmptyCard, fsrs, generatorParameters, Rating, type Card, type Grade } from 'ts-fsrs'
 import type { UserProgress, ExerciseType } from './types'
 
 const params = generatorParameters({
@@ -55,7 +55,7 @@ export function createNewProgress(speciesId: string): UserProgress {
   }
 }
 
-export function scheduleReview(progress: UserProgress, rating: Rating): UserProgress {
+export function scheduleReview(progress: UserProgress, rating: Grade): UserProgress {
   const card = progressToCard(progress)
   const now = new Date()
   const result = scheduler.repeat(card, now)
@@ -86,7 +86,7 @@ export function ratingFromOutcome(
   correct: boolean,
   responseTimeMs: number,
   exerciseType: ExerciseType,
-): Rating {
+): Grade {
   if (!correct) return Rating.Again
 
   const { fast, slow } = THRESHOLDS[exerciseType]

--- a/beakspeak/src/core/lesson.test.ts
+++ b/beakspeak/src/core/lesson.test.ts
@@ -107,7 +107,7 @@ describe('buildIntroQuiz', () => {
   const lessonSpecies = ['a', 'b', 'c'].map(makeSpecies)
 
   it('generates quiz items for the lesson species', () => {
-    const items = buildIntroQuiz(lessons[0], lessonSpecies, [], lessonSpecies)
+    const items = buildIntroQuiz(lessonSpecies, [])
     expect(items.length).toBeGreaterThanOrEqual(3)
     expect(items.length).toBeLessThanOrEqual(5)
     items.forEach(item => {
@@ -118,7 +118,7 @@ describe('buildIntroQuiz', () => {
 
   it('uses previously introduced species as distractors when available', () => {
     const previouslyIntroduced = ['x', 'y', 'z'].map(makeSpecies)
-    const items = buildIntroQuiz(lessons[0], lessonSpecies, previouslyIntroduced, [...lessonSpecies, ...previouslyIntroduced])
+    const items = buildIntroQuiz(lessonSpecies, previouslyIntroduced)
     items.forEach(item => {
       // Correct answer must be in choices
       expect(item.choices.map(c => c.id)).toContain(item.targetSpecies.id)
@@ -127,6 +127,28 @@ describe('buildIntroQuiz', () => {
       item.choices.forEach(c => {
         expect(allIds).toContain(c.id)
       })
+    })
+  })
+
+  it('keeps at least two current-lesson birds in each set of choices', () => {
+    const previouslyIntroduced = ['x', 'y', 'z', 'w'].map(makeSpecies)
+    const items = buildIntroQuiz(lessonSpecies, previouslyIntroduced)
+
+    items.forEach(item => {
+      const lessonChoiceCount = item.choices.filter(choice =>
+        lessonSpecies.some(species => species.id === choice.id),
+      ).length
+
+      expect(lessonChoiceCount).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  it('never returns duplicate choices', () => {
+    const previouslyIntroduced = ['x', 'y', 'z', 'w'].map(makeSpecies)
+    const items = buildIntroQuiz(lessonSpecies, previouslyIntroduced)
+
+    items.forEach(item => {
+      expect(new Set(item.choices.map(choice => choice.id)).size).toBe(item.choices.length)
     })
   })
 })
@@ -141,5 +163,14 @@ describe('buildReviewQuiz', () => {
     const items = buildReviewQuiz(introduced)
     expect(items.length).toBeGreaterThanOrEqual(2)
     expect(items.length).toBeLessThanOrEqual(3)
+  })
+
+  it('never returns duplicate choices', () => {
+    const introduced = ['a', 'b', 'c', 'd', 'e'].map(makeSpecies)
+    const items = buildReviewQuiz(introduced)
+
+    items.forEach(item => {
+      expect(new Set(item.choices.map(choice => choice.id)).size).toBe(item.choices.length)
+    })
   })
 })

--- a/beakspeak/src/core/lesson.ts
+++ b/beakspeak/src/core/lesson.ts
@@ -46,11 +46,27 @@ function pickRandom<T>(array: T[], count: number): T[] {
   return shuffle(array).slice(0, count)
 }
 
+function buildThreeChoices(
+  target: Species,
+  preferredDistractors: Species[],
+  fallbackDistractors: Species[],
+): Species[] {
+  const seen = new Set<string>([target.id])
+  const distractors: Species[] = []
+
+  for (const candidate of [...preferredDistractors, ...fallbackDistractors]) {
+    if (seen.has(candidate.id)) continue
+    seen.add(candidate.id)
+    distractors.push(candidate)
+    if (distractors.length === 2) break
+  }
+
+  return shuffle([target, ...distractors])
+}
+
 export function buildIntroQuiz(
-  lesson: Lesson,
   lessonSpecies: Species[],
   previouslyIntroduced: Species[],
-  _allSpecies: Species[],
 ): IntroQuizItem[] {
   // Generate 3-5 questions testing the lesson species
   const targetCount = Math.min(5, Math.max(3, lessonSpecies.length + 2))
@@ -63,13 +79,16 @@ export function buildIntroQuiz(
   targets = shuffle(targets)
 
   return targets.map(target => {
-    // Build 3-choice: target + 2 distractors
-    const distractorPool = [
-      ...lessonSpecies.filter(s => s.id !== target.id),
+    // Keep at least two current-lesson birds in the options when possible.
+    const lessonDistractors = pickRandom(
+      lessonSpecies.filter(s => s.id !== target.id),
+      1,
+    )
+    const remainingDistractorPool = shuffle([
+      ...lessonSpecies.filter(s => s.id !== target.id && !lessonDistractors.some(d => d.id === s.id)),
       ...previouslyIntroduced.filter(s => s.id !== target.id),
-    ]
-    const distractors = pickRandom(distractorPool, 2)
-    const choices = shuffle([target, ...distractors])
+    ])
+    const choices = buildThreeChoices(target, lessonDistractors, remainingDistractorPool)
 
     // Pick a random song clip for the question
     const allClips = [...target.audio_clips.songs, ...target.audio_clips.calls]
@@ -88,9 +107,8 @@ export function buildReviewQuiz(
   const targets = pickRandom(introducedSpecies, count)
 
   return targets.map(target => {
-    const distractorPool = introducedSpecies.filter(s => s.id !== target.id)
-    const distractors = pickRandom(distractorPool, 2)
-    const choices = shuffle([target, ...distractors])
+    const distractorPool = shuffle(introducedSpecies.filter(s => s.id !== target.id))
+    const choices = buildThreeChoices(target, distractorPool, [])
 
     const allClips = [...target.audio_clips.songs, ...target.audio_clips.calls]
     const clip = allClips[Math.floor(Math.random() * allClips.length)] ?? target.audio_clips.songs[0]

--- a/beakspeak/src/core/quiz.test.ts
+++ b/beakspeak/src/core/quiz.test.ts
@@ -104,4 +104,25 @@ describe('buildQuizSession', () => {
     expect(session.length).toBeGreaterThanOrEqual(8)
     expect(session.length).toBeLessThanOrEqual(10)
   })
+
+  it('never returns duplicate choices in three-choice items', () => {
+    const speciesIds = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
+    const allSpecies = speciesIds.map(makeSpecies)
+    const progress = new Map(speciesIds.map(id => [id, makeProgress(id)]))
+    const manifest = {
+      version: '0.1.0', tier: 1, region: 'Test', target_species_count: 8,
+      curation_date: '2026-01-01', data_sources: {},
+      species: allSpecies,
+      confuser_pairs: [],
+      lesson_plan: { description: 'test', lessons: [] },
+    } as Manifest
+
+    const session = buildQuizSession(progress, manifest, new Map())
+
+    session
+      .filter(item => item.exerciseType === 'three_choice' && item.choices)
+      .forEach(item => {
+        expect(new Set(item.choices!.map(choice => choice.id)).size).toBe(item.choices!.length)
+      })
+  })
 })

--- a/beakspeak/src/core/quiz.ts
+++ b/beakspeak/src/core/quiz.ts
@@ -10,8 +10,18 @@ function shuffle<T>(array: T[]): T[] {
   return result
 }
 
-function pickRandom<T>(array: T[], count: number): T[] {
-  return shuffle(array).slice(0, count)
+function buildThreeChoices(target: Species, distractors: Species[]): Species[] {
+  const seen = new Set<string>([target.id])
+  const uniqueDistractors: Species[] = []
+
+  for (const distractor of distractors) {
+    if (seen.has(distractor.id)) continue
+    seen.add(distractor.id)
+    uniqueDistractors.push(distractor)
+    if (uniqueDistractors.length === 2) break
+  }
+
+  return shuffle([target, ...uniqueDistractors])
 }
 
 export function selectExerciseType(progress: UserProgress): ExerciseType {
@@ -45,10 +55,12 @@ export function selectDistractors(
   const distractors: Species[] = []
   for (const s of shuffle(confuserPool)) {
     if (distractors.length >= distractorCount) break
+    if (distractors.some(d => d.id === s.id)) continue
     distractors.push(s)
   }
   for (const s of shuffle(otherPool)) {
     if (distractors.length >= distractorCount) break
+    if (distractors.some(d => d.id === s.id)) continue
     distractors.push(s)
   }
 
@@ -177,7 +189,7 @@ export function buildQuizSession(
         targetSpecies: species,
         exerciseType: 'three_choice',
         clip,
-        choices: shuffle([species, ...distractors]),
+        choices: buildThreeChoices(species, distractors),
       })
     } else {
       items.push(buildSameDifferentItem(species, introduced, confuserPairs, lastPlayedClipId))
@@ -196,7 +208,7 @@ export function buildQuizSession(
         targetSpecies: species,
         exerciseType: 'three_choice',
         clip,
-        choices: shuffle([species, ...distractors]),
+        choices: buildThreeChoices(species, distractors),
       })
     }
   }

--- a/beakspeak/src/core/spectrogram.test.ts
+++ b/beakspeak/src/core/spectrogram.test.ts
@@ -3,7 +3,7 @@ import { computeSpectrogram } from './spectrogram'
 
 function makeAudioBuffer(samples: Float32Array, sampleRate: number) {
   return {
-    getChannelData: (_channel: number) => samples,
+    getChannelData: () => samples,
     length: samples.length,
     duration: samples.length / sampleRate,
     sampleRate,

--- a/beakspeak/src/hooks/useAudioStateForUrl.ts
+++ b/beakspeak/src/hooks/useAudioStateForUrl.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useCallback, useSyncExternalStore } from 'react'
 import type { AudioPlayer, AudioState } from '../adapters/audio'
 
 /**
@@ -6,17 +6,14 @@ import type { AudioPlayer, AudioState } from '../adapters/audio'
  * Returns 'idle' whenever a different clip is active.
  */
 export function useAudioStateForUrl(audioPlayer: AudioPlayer, url: string): AudioState {
-  const [state, setState] = useState<AudioState>(() =>
-    audioPlayer.getActiveUrl() === url ? audioPlayer.getState() : 'idle',
+  const getSnapshot = useCallback(
+    (): AudioState => (audioPlayer.getActiveUrl() === url ? audioPlayer.getState() : 'idle'),
+    [audioPlayer, url],
   )
-  useEffect(() => {
-    // Re-sync on url change — useState initializer only runs once on mount
-    setState(audioPlayer.getActiveUrl() === url ? audioPlayer.getState() : 'idle')
-    const unsub = audioPlayer.onStateChange((s) => {
-      const activeUrl = audioPlayer.getActiveUrl()
-      setState(activeUrl === url ? s : 'idle')
-    })
-    return unsub
-  }, [audioPlayer, url])
-  return state
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => audioPlayer.onStateChange(() => onStoreChange()),
+    [audioPlayer],
+  )
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
 }

--- a/beakspeak/test-results/.last-run.json
+++ b/beakspeak/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/beakspeak/vite.config.ts
+++ b/beakspeak/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { configDefaults } from 'vitest/config'
 
 export default defineConfig({
   base: '/beakspeak/',
@@ -9,5 +10,6 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
+    exclude: ['e2e/**', ...configDefaults.exclude],
   },
 })

--- a/rpi/plan/2026-04-22-unlockable-guided-path.md
+++ b/rpi/plan/2026-04-22-unlockable-guided-path.md
@@ -5,79 +5,135 @@
 
 ## Problem
 
-The default learning experience is intentionally guided: lessons unlock sequentially, reviews follow FSRS scheduling, and completed lessons can't be revisited. This is pedagogically sound but frustrating for power users who want more control. We should let people transparently step off the guided path when they choose to.
+The default learning experience is intentionally guided: lessons unlock sequentially, reviews follow FSRS scheduling, and completed lessons cannot be revisited. This is pedagogically sound but frustrating for power users who want more control. We should let people transparently step off the guided path when they choose to, while keeping the guided path as the default.
 
 ## Three Features
 
 ### 1. Unlock Future Lessons on Click
 
-**Current behavior:** Clicking a locked lesson does nothing (`disabled={!available || completed}` in `LearnTab.tsx:56`). Locking is enforced by `isLessonAvailable()` in `lesson.ts:3-16` — it checks that the previous lesson is complete and no birds are in relearning state.
+**Current behavior:** Clicking a locked lesson does nothing because locked lessons are disabled in `LearnTab.tsx`. Locking is enforced by `isLessonAvailable()` in `lesson.ts`, which blocks a lesson if the previous lesson is incomplete or any bird is in relearning.
 
-**New behavior:** Clicking a locked lesson shows a confirmation dialog explaining *why* it's locked and offering to unlock it anyway. Unlocking auto-completes all skipped lessons between the last completed lesson and the selected one.
+**New behavior:** Clicking a locked lesson opens a confirmation modal that explains why the lesson is locked and what bypassing the guardrail will do. Confirming the modal immediately marks skipped lessons as learned, then launches the selected lesson in unlock mode.
 
 **Implementation:**
 
-- **LearnTab.tsx:** Remove `disabled` from locked lessons. On click of a locked lesson, instead of launching `LearnSession`, show a modal/dialog.
-  - Dialog copy varies by lock reason:
-    - *Previous lesson not complete:* "This lesson is locked so you don't learn too many birds at once. Want to unlock it anyway?"
-    - *Birds in relearning:* "Some birds need more practice before new lessons. Want to skip ahead anyway?"
-  - "Unlock" button calls `introduceSpecies()` for all skipped lessons' species, then sets `activeLesson` and launches `LearnSession`.
-  - "Never mind" dismisses the dialog.
-- **LearnSession.tsx:** No changes needed — it already works with any `Lesson` object regardless of lock state.
-- **lesson.ts:** No changes. Locking logic stays intact; the UI bypasses the gate. This keeps `isLessonAvailable()` useful for determining *why* something is locked (for the dialog copy) and for tests.
+- **LearnTab.tsx**
+  - Remove the disabled behavior for locked lessons.
+  - Clicking a locked lesson opens `UnlockDialog` instead of launching the lesson directly.
+  - Maintain explicit local launch state for lessons, e.g. `{ lesson, mode: 'normal' | 'unlock' | 'redo' }`.
+  - Confirmation is a one-launch bypass only. If the user backs out of the launched lesson and the guardrail still applies later, they must confirm again.
+  - Auto-complete only the skipped intervening lessons, not the selected lesson itself.
+  - Mark skipped lessons learned immediately on confirmation, not at the end of the selected lesson.
+  - Preserve any existing progress for skipped species and only fill in missing introductions.
 
-**Auto-completion of skipped lessons:** When a user unlocks Lesson 4, Lessons 2 and 3 are auto-completed — their species are marked `introduced: true` and enter the FSRS review pool immediately as due. This means:
-- Skipped birds appear as both quiz targets and distractors right away.
-- If the user doesn't actually know those birds, FSRS will catch it (wrong answers trigger relearning). The system self-corrects.
-- We trust the user's implicit claim that they already know the earlier birds.
+- **UnlockDialog.tsx**
+  - Use a true modal, not inline expansion.
+  - Allow both outside-tap dismissal and an explicit `Never mind` button.
+  - Use reason-specific titles:
+    - `Take It Step by Step` for missing prerequisites
+    - `Practice First` for relearning
+  - Lead with the rationale first, then the consequence.
+  - Use reason-specific primary CTAs:
+    - `Skip Ahead Anyway` for prerequisite-only locks
+    - `Open Lesson Anyway` for relearning locks
+    - If both reasons apply, use the relearning framing and `Open Lesson Anyway`
+  - When skipped lessons will be marked learned, explicitly name the lesson numbers and bird count if small and deterministic:
+    - List exact lesson numbers when at most 3 lessons are skipped
+    - Otherwise summarize as a range
+  - If no lessons will be auto-completed, use copy that explicitly says the lesson will open now but nothing will be marked learned unless the lesson is completed.
+  - Use user-facing language like “those birds will start showing up in your reviews,” not internal terms like “review pool.”
 
-**New component:** `UnlockDialog` — a small confirmation modal. Receives `reason: 'prerequisites' | 'relearning'` and `onConfirm`/`onDismiss` callbacks.
+- **LearnSession.tsx**
+  - Accept a single explicit `mode: 'normal' | 'unlock' | 'redo'` prop.
+  - `unlock` mode skips the review warm-up.
+  - `unlock` mode otherwise behaves like a normal lesson: cards, intro quiz, then introduce the selected lesson species on completion.
+
+- **core/lesson.ts**
+  - Add a helper that returns the structured lock reason, with relearning taking precedence over prerequisites.
+  - Keep `isLessonAvailable()` and have it delegate to the new helper.
+  - Do not move unlock modal consequence formatting into core; keep that in the learn UI layer.
+
+**Auto-completion of skipped lessons:** When a user unlocks Lesson 4, Lessons 2 and 3 are auto-completed immediately on confirmation. Their species are marked `introduced: true` and will appear in normal review generation right away as both quiz targets and distractors. If the user does not actually know those birds, the normal review system will surface that.
 
 ---
 
 ### 2. Practice When Nothing Is Due
 
-**Current behavior:** When no birds are due for review, `QuizTab.tsx:53-68` shows "No birds due for review right now" and either a relearning warning or a "Learn More Birds" button. There's no way to practice.
+**Current behavior:** When no birds are due for review, `QuizTab.tsx` shows a dead-end empty state with either a relearning warning or a `Learn More Birds` button. There is no way to practice.
 
-**New behavior:** Always show a "Practice Anyway" option, with a gentle nudge that it may have diminishing returns.
+**New behavior:** When nothing is due and the user has learned enough birds to make practice meaningful, offer a `Practice Anyway` path that is completely side-effect-free.
 
 **Implementation:**
 
-- **QuizTab.tsx:** In the `dueForReview.length === 0` branch, replace the "Learn More Birds" button with two elements:
-  1. A message: "No birds are due right now. Practicing too much may have diminishing returns, but you can practice anyway."
-  2. A "Practice Anyway" button that launches a quiz session in practice mode.
-  - Keep the "Learn More Birds" button as a secondary option below if there are unlearned lessons remaining.
-  - If relearning birds exist, still show the relearning message but *also* show "Practice Anyway".
+- **QuizTab.tsx**
+  - Keep the practice-availability rule in `QuizTab`, not in core.
+  - Show `Practice Anyway` only when:
+    - no birds are due, and
+    - at least 3 birds have been introduced
+  - CTA hierarchy when practice is available:
+    - If unlearned lessons remain and the guided path is actually available, keep `Learn More Birds` as the primary CTA and `Practice Anyway` as the secondary CTA.
+    - If relearning birds exist and block the guided path, show the relearning message and make `Practice Anyway` the only actionable CTA.
+    - If all lessons are complete, show only `Practice Anyway`.
+  - Do not offer `Practice Anyway` alongside `Start Review` when birds are due.
 
-- **quiz.ts `buildQuizSession()`:** No changes needed — the existing padding logic already builds an 8-question session from introduced birds when 0 are due.
+- **QuizSession.tsx**
+  - Accept a single explicit `mode: 'review' | 'practice'` prop.
+  - `practice` mode reuses the normal quiz mix, including `same_different` for higher-rep birds.
+  - `practice` mode skips all persistent side effects:
+    - no `scheduleReview()`
+    - no confusion logging
+  - Keep the existing top header row and `Quit` label.
+  - Add a small inline label beneath the header in practice mode:
+    - Title: `Practice Session`
+    - Subcopy: `This won't change your review schedule`
 
-- **QuizSession.tsx:** Accept a `practiceMode?: boolean` prop. When `practiceMode` is true, **skip all `scheduleReview()` calls**. The session is fully FSRS-inert — no scheduling updates, no stability changes, no relearning triggers. It's a pure listening/recognition exercise.
+- **QuizResult.tsx**
+  - Derive mode-specific copy from the `mode` prop internally.
+  - In practice mode, explicitly state that the session did not change the review schedule.
+  - Keep the existing `Needs More Practice` heading for incorrect birds.
 
-**Rationale for FSRS-inert practice:** FSRS is designed around spaced intervals. Cramming data pollutes the model. This matches Anki's own pattern — their filtered/cram decks have a "Reschedule cards based on my answers" toggle, and the recommendation for cram sessions is to turn rescheduling off (Anki calls this "preview mode").
+- **core/quiz.ts**
+  - No special practice-mode logic needed.
+  - Practice reuses the same quiz construction as review mode.
 
-**Edge case:** If only 1-2 birds are introduced, distractor pools are very small. `buildQuizSession` already handles this gracefully (falls back to whatever is available), so no special handling needed.
+**Rationale for FSRS-inert practice:** FSRS is designed around spaced intervals. Cramming data pollutes the model. Practice here is a preview-style session, not a scheduling event.
+
+**Edge case:** If fewer than 3 birds are introduced, do not offer `Practice Anyway`. The current quiz builder can technically limp along with fewer choices, but the result is too weak to be worth presenting as a real practice mode.
 
 ---
 
 ### 3. Redo a Completed Lesson
 
-**Current behavior:** Completed lessons show a green checkmark and are disabled (`disabled={!available || completed}` in `LearnTab.tsx:56`). Users cannot revisit the cards or hear the birds again.
+**Current behavior:** Completed lessons show a green checkmark and are disabled. Users cannot revisit the cards or hear the birds again.
 
-**New behavior:** Clicking a completed lesson re-launches the lesson — same cards, same audio, same intro quiz — but without re-running `introduceSpecies()`.
+**New behavior:** Clicking a completed lesson launches that lesson again in redo mode. Redo exists for refresher study, not for changing review state.
 
 **Implementation:**
 
-- **LearnTab.tsx:** Remove `completed` from the disabled condition. Completed lessons become clickable. On click of a completed lesson, launch `LearnSession` with a `redo` flag.
+- **LearnTab.tsx**
+  - Remove the disabled behavior for completed lessons.
+  - Completed lessons remain visually distinct via their existing success styling, but do not need extra `Redo` labels or badges.
+  - Clicking a completed lesson launches `LearnSession` in `redo` mode immediately, even if birds are currently in relearning.
 
-- **LearnSession.tsx:** Accept an optional `redo?: boolean` prop.
-  - When `redo` is true:
-    - Skip the review warm-up phase (they're choosing to study specific birds, not warm up).
-    - Show cards phase as normal (primary value — re-hearing the birds).
-    - Show the intro quiz as normal (valuable "did I re-absorb this?" check; user can back out if they don't want it).
-    - On quiz complete: do NOT call `introduceSpecies()` (already introduced). Show a "Nice refresher!" completion screen instead of "Lesson Complete! You've learned..."
-  - Early exit (Back button) behavior: identical to normal lessons — return to lesson list, no side effects. Harmless in both modes since redo has no state to corrupt.
+- **LearnSession.tsx**
+  - `redo` mode skips the review warm-up.
+  - `redo` mode still shows:
+    - cards
+    - audio
+    - intro quiz
+  - `redo` mode does not call `introduceSpecies()` on completion, because completed lessons already have introduced species.
+  - `redo` mode is scheduling-neutral. It is a refresher, not a review session.
+  - The completion screen should say both:
+    - that it was a refresher
+    - that the review schedule was not changed
+  - The primary completion button in redo mode should be `Back to Lessons`.
+  - Normal and unlock lesson completions should keep `Continue`.
 
-- **lesson.ts:** No changes.
+- **IntroQuiz.tsx**
+  - Add an optional `onBack` prop.
+  - When present, render a top-left `Back` link internally.
+  - Use this `Back` link for all `LearnSession` quiz flows, not only redo.
+  - In lesson quiz flows, `Back` always exits the lesson session back to the lesson list. It does not mean “skip this quiz and continue.”
 
 ---
 
@@ -85,40 +141,87 @@ The default learning experience is intentionally guided: lessons unlock sequenti
 
 | Decision | Resolution | Rationale |
 |----------|-----------|-----------|
-| Auto-unlock vs auto-complete skipped lessons | Auto-complete (introduce species) | Unlocking without introducing doesn't help — birds need to be in the pool. Trust the user knows them; FSRS self-corrects if they don't. |
-| Practice Anyway + FSRS | Fully FSRS-inert | Cramming pollutes FSRS stability scores. Matches Anki's "preview mode" for cram decks. |
-| Redo: skip intro quiz? | Keep it | Adds value as a re-absorption check. User can bail via Back button if they don't want it. |
-| Shared confirmation component? | No — keep separate | Unlock dialog is a modal, practice-anyway is inline copy, redo completion is a different screen title. Different enough to not warrant abstraction. |
-| Skipped species as targets or distractors only? | Both | No gaming risk — quiz code already mixes lesson birds into both roles. Target/distractor is an internal role, not user-visible. |
-| Back button behavior during redo | Same as normal | No side effects in either mode. Back means back. |
+| Unlock skipped lessons vs auto-complete them | Auto-complete skipped intervening lessons | Unlocking without introducing species does not help; birds need to enter the normal learning pool. |
+| When to mark skipped lessons learned | Immediately on confirmation | Unlocking is the state-changing act. The dialog should be truthful at the moment of confirmation. |
+| Does selected lesson auto-complete on unlock | No | Only intervening lessons are auto-completed; the selected lesson still runs normally. |
+| Preserve or reset existing skipped-bird progress | Preserve existing progress | Do not destroy legitimate history for already-introduced species. |
+| Relearning vs prerequisites precedence | Relearning wins | It is the stronger guardrail and should control the reason shown. |
+| Manual unlock persistence | One-launch only | Avoid storing “manually unlocked” state; keep bypasses explicit and local. |
+| Unlock modal dismissal | Outside tap and `Never mind` | Dismissal is harmless; confirmation remains explicit. |
+| Unlock modal titles | Reason-specific explanatory titles | Titles explain the guardrail; buttons carry the override. |
+| Prerequisite title | `Take It Step by Step` | Pedagogical framing fits the product voice. |
+| Relearning title | `Practice First` | Short, clear, mobile-friendly. |
+| Unlock modal button labels | `Skip Ahead Anyway` or `Open Lesson Anyway` | More truthful than a generic “Unlock.” |
+| Unlock modal consequence copy | Explicit lesson numbers and bird counts when small/deterministic | Makes the cost of skipping legible. |
+| Exact lesson-number cutoff | List exact lessons up to 3 skipped lessons | Beyond that, summarize as a range. |
+| LearnSession mode shape | Single `mode` prop | Clearer than stacking booleans for normal/unlock/redo. |
+| LearnSession mode type location | Local to component | These are UI flow semantics, not domain types. |
+| LearnSession copy ownership | Inside `LearnSession` | Copy is tightly coupled to mode-specific behavior. |
+| Warm-up in unlock mode | Skip it | Unlock should open the selected lesson directly. |
+| Warm-up in redo mode | Skip it | Redo is targeted refresher study, not warm-up. |
+| Redo intro quiz | Keep it | Still useful as a re-absorption check. |
+| Redo scheduling | Fully inert | Redo is refresher study, not review. |
+| Redo availability during relearning | Allow it | Relearning should block new lessons, not extra exposure to known birds. |
+| Lesson-quiz `Back` behavior | Exit lesson session | Keep `Back` semantics consistent across lesson flows. |
+| IntroQuiz back-header ownership | `IntroQuiz` via optional `onBack` | Keeps one screen’s chrome inside one component. |
+| Practice availability threshold | Require at least 3 introduced birds | Avoid weak/trivial sessions with too few choices. |
+| Practice availability when due birds exist | Do not show it | Keep the scheduled review path primary. |
+| Practice availability when relearning blocks learning | Show relearning message plus only `Practice Anyway` | Avoid a false `Learn More Birds` CTA. |
+| Practice availability when all lessons complete | Show only `Practice Anyway` | `Learn More Birds` is no longer truthful. |
+| Practice CTA hierarchy when guided path is available | `Learn More Birds` primary, `Practice Anyway` secondary | Nudge toward the guided path without removing the bypass. |
+| Practice session side effects | None | No scheduling updates and no confusion logging. |
+| Practice session quiz mix | Reuse normal review mix | Practice should be inert, not pedagogically different. |
+| Practice session labeling | Label in-session and in results | Set expectations before and after the session. |
+| Practice-mode header layout | Keep existing header, add label beneath | Preserve the established session chrome. |
+| Practice-mode result heading | Keep `Needs More Practice` | Simpler UI logic; difference is carried by the schedule disclaimer. |
+| QuizSession mode shape | Single `mode` prop | Same reasoning as LearnSession: explicit semantics beat booleans. |
+| QuizSession mode type location | Local to component | UI flow concern, not domain type. |
+| QuizResult copy ownership | Inside `QuizResult` | Keep mode-specific rendering logic with the component that owns it. |
+| QuizSession exit label in practice mode | Keep `Quit` | Consistent with normal quiz session chrome. |
+| Lock-reason helper location | `core/lesson.ts` | Lock reason is domain logic and should be testable. |
+| Unlock-copy consequence helper location | Local helper in `learn/` | UI formatting rules do not belong in core. |
+| `isLessonAvailable()` fate | Keep it and delegate | Minimizes churn while enabling richer callers. |
+| Required tests | Test pure logic plus highest-risk branch behavior | Good regression protection without over-investing in UI test volume. |
 
 ## Shared UX Considerations
 
-- **Transparent friction:** Each feature tells the user *why* the guardrail exists before letting them bypass it. The goal is informed choice, not hidden options.
-- **No settings/preferences:** These are point-of-use decisions, not global toggles. Keep the default path guided.
-- **Self-correcting:** The only permanent state change is auto-completing skipped lessons. If the user was wrong about knowing those birds, FSRS catches it through normal review. Practice-anyway and redo have zero persistent side effects.
+- **Transparent friction:** Explain the guardrail first, then explain the consequence of bypassing it.
+- **Guided path remains the default:** The bypasses are point-of-use decisions, not global settings or preferences.
+- **Only one durable bypass side effect:** Unlocking ahead can mark skipped lessons learned immediately. Practice and redo are both side-effect-free.
+- **Consistent session semantics:** `Back` exits lesson study; `Quit` exits quiz sessions; warm-up exists only for normal lesson launches.
 
 ## Files Changed
 
 | File | Change |
 |------|--------|
-| `beakspeak/src/components/learn/LearnTab.tsx` | Remove disabled on locked/completed, add unlock dialog and redo mode |
-| `beakspeak/src/components/learn/LearnSession.tsx` | Add `redo` prop, skip review phase and `introduceSpecies` on redo |
-| `beakspeak/src/components/quiz/QuizTab.tsx` | Add "Practice Anyway" button and inline copy when nothing due |
-| `beakspeak/src/components/quiz/QuizSession.tsx` | Add `practiceMode` prop, skip `scheduleReview()` when true |
-| `beakspeak/src/components/learn/UnlockDialog.tsx` | **New** — confirmation modal for unlocking lessons |
+| `beakspeak/src/components/learn/LearnTab.tsx` | Unlock modal flow, explicit lesson launch state, normal/unlock/redo launch routing |
+| `beakspeak/src/components/learn/LearnSession.tsx` | Single `mode` prop, skip warm-up for unlock/redo, redo-specific completion copy |
+| `beakspeak/src/components/learn/IntroQuiz.tsx` | Optional `onBack` prop and internal lesson-quiz header |
+| `beakspeak/src/components/learn/UnlockDialog.tsx` | New modal component for locked-lesson bypass flow |
+| `beakspeak/src/components/learn/*` | Small local helper for unlock modal copy assembly |
+| `beakspeak/src/components/quiz/QuizTab.tsx` | Practice CTA gating and empty-state branching |
+| `beakspeak/src/components/quiz/QuizSession.tsx` | Single `mode` prop, practice labeling, skip persistent side effects in practice |
+| `beakspeak/src/components/quiz/QuizResult.tsx` | Mode-derived copy, explicit practice disclaimer |
+| `beakspeak/src/core/lesson.ts` | New structured lock-reason helper; `isLessonAvailable()` delegates |
+| `beakspeak/src/core/lesson.test.ts` | Tests for lock-reason precedence and related pure logic |
+| `beakspeak/src/components/*/*.test.tsx` | Focused tests for key UI branch behavior |
 
 ## Files NOT Changed
 
 | File | Why |
 |------|-----|
-| `beakspeak/src/core/lesson.ts` | Locking logic stays; UI bypasses the gate |
-| `beakspeak/src/core/quiz.ts` | Padding logic already handles 0-due sessions |
-| `beakspeak/src/core/fsrs.ts` | Not touched; practice mode skips it entirely |
-| `beakspeak/src/store/appStore.ts` | No new persistent state needed |
+| `beakspeak/src/core/fsrs.ts` | FSRS behavior itself is unchanged; practice/redo avoid touching it |
+| `beakspeak/src/core/quiz.ts` | Practice reuses normal quiz construction |
+| `beakspeak/src/store/appStore.ts` | No new persistent “manual unlock” or session-mode state is needed |
+| `beakspeak/src/core/types.ts` | Session modes stay local to UI components |
 
 ## Order of Implementation
 
-1. **UnlockDialog component + LearnTab unlock flow** — includes auto-completing skipped lessons
-2. **Redo lessons** — LearnTab clickability + LearnSession `redo` prop
-3. **Practice anyway** — QuizTab inline copy + QuizSession `practiceMode` prop
+1. **Lock reason + unlock flow**
+   Update `core/lesson.ts`, add `UnlockDialog`, add local unlock-copy helper, wire locked-lesson modal flow in `LearnTab`.
+2. **Lesson session modes**
+   Convert `LearnSession` to explicit `mode`, add redo/unlock warm-up behavior, update `IntroQuiz` with optional `onBack`.
+3. **Practice mode**
+   Add `QuizSession` mode, side-effect-free practice behavior, in-session/results labeling, and updated `QuizTab` empty-state branching.
+4. **Tests**
+   Add unit tests for pure lock-reason logic and focused component tests for the high-risk new branches.


### PR DESCRIPTION
This PR packages the testing workflow updates and the 2026-04-22 unlockable guided path plan change.\n\nIncluded:\n- README testing guidance for typecheck, lint, unit tests, mobile E2E, and CI\n- AGENTS.md guidance on when each validation layer should run\n- Playwright fixture and mobile E2E coverage\n- related test/lint/typecheck fixes surfaced by the new validation layers\n- rpi/plan/2026-04-22-unlockable-guided-path.md