### PR TITLE
[codex] Add unlockable guided path flow

### DIFF
--- a/beakspeak/src/components/learn/IntroQuiz.test.tsx
+++ b/beakspeak/src/components/learn/IntroQuiz.test.tsx
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import IntroQuiz from './IntroQuiz'
+import type { AudioPlayer, AudioState } from '../../adapters/audio'
+import type { IntroQuizItem, Species } from '../../core/types'
+
+function makeMockAudioPlayer(overrides: Partial<AudioPlayer> = {}): AudioPlayer {
+  return {
+    play: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn(),
+    seek: vi.fn(),
+    isPlaying: vi.fn(() => false),
+    getState: vi.fn((): AudioState => 'idle'),
+    getActiveUrl: vi.fn(() => null),
+    getProgress: vi.fn(() => ({ currentTime: 0, duration: 0 })),
+    onStateChange: vi.fn(() => () => {}),
+    onProgress: vi.fn(() => () => {}),
+    prefetch: vi.fn(async () => null),
+    getBuffer: vi.fn(() => null),
+    ...overrides,
+  }
+}
+
+function makeSpecies(id: string): Species {
+  return {
+    id,
+    common_name: id.toUpperCase(),
+    scientific_name: `Genus ${id}`,
+    family: 'TestFamily',
+    ebird_frequency_pct: 50,
+    habitat: ['backyard'],
+    seasonality: 'year-round',
+    mnemonic: `mnemonic for ${id}`,
+    sound_types: { song: 'test song', call: 'test call' },
+    confuser_species: [],
+    confuser_notes: '',
+    audio_clips: {
+      songs: [
+        {
+          xc_id: `${id}-song`,
+          xc_url: '',
+          audio_url: `/${id}.ogg`,
+          type: 'song',
+          quality: 'A',
+          length: '0:10',
+          recordist: 'test',
+          license: 'CC',
+          location: '',
+          country: '',
+          score: 10,
+        },
+      ],
+      calls: [],
+    },
+    photo: {
+      url: `/${id}.jpg`,
+      filename: `${id}.jpg`,
+      source: 'test',
+      license: 'CC',
+      wikipedia_page: '',
+    },
+  }
+}
+
+function makeItem(): IntroQuizItem {
+  const target = makeSpecies('a')
+  return {
+    targetSpecies: target,
+    clip: target.audio_clips.songs[0],
+    choices: [target, makeSpecies('b'), makeSpecies('c')],
+  }
+}
+
+let mockAudioPlayer: AudioPlayer
+
+vi.mock('../../store/appStore', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ audioPlayer: mockAudioPlayer }),
+}))
+
+vi.mock('../../hooks/useAudioStateForUrl', () => ({
+  useAudioStateForUrl: vi.fn(() => 'idle'),
+}))
+
+describe('IntroQuiz back navigation', () => {
+  beforeEach(() => {
+    mockAudioPlayer = makeMockAudioPlayer()
+  })
+
+  it('renders an optional Back action and calls it', () => {
+    const onBack = vi.fn()
+
+    render(
+      <IntroQuiz
+        items={[makeItem()]}
+        onComplete={vi.fn()}
+        onBack={onBack}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+
+    expect(onBack).toHaveBeenCalledTimes(1)
+  })
+})

--- a/beakspeak/src/components/learn/IntroQuiz.tsx
+++ b/beakspeak/src/components/learn/IntroQuiz.tsx
@@ -6,9 +6,10 @@ import type { IntroQuizItem } from '../../core/types'
 interface Props {
   items: IntroQuizItem[]
   onComplete: (results: Array<{ correct: boolean }>) => void
+  onBack?: () => void
 }
 
-export default function IntroQuiz({ items, onComplete }: Props) {
+export default function IntroQuiz({ items, onComplete, onBack }: Props) {
   const audioPlayer = useAppStore(s => s.audioPlayer)
   const [currentIndex, setCurrentIndex] = useState(0)
   const [selectedId, setSelectedId] = useState<string | null>(null)
@@ -68,10 +69,24 @@ export default function IntroQuiz({ items, onComplete }: Props) {
   return (
     <div className="flex flex-col h-full overflow-y-auto">
       <div className="p-4 flex flex-col flex-1">
-        <div className="text-center mb-4">
-          <p className="text-xs text-text-muted mb-2">
+        <div className="mb-4 flex items-center justify-between gap-3">
+          {onBack ? (
+            <button
+              onClick={onBack}
+              className="text-sm text-text-muted"
+            >
+              Back
+            </button>
+          ) : (
+            <span />
+          )}
+          <p className="text-xs text-text-muted">
             Question {currentIndex + 1} of {items.length}
           </p>
+          <span />
+        </div>
+
+        <div className="text-center mb-4">
           <button
             onClick={() => {
               if (playState === 'playing') audioPlayer.stop()

--- a/beakspeak/src/components/learn/LearnSession.test.tsx
+++ b/beakspeak/src/components/learn/LearnSession.test.tsx
@@ -1,0 +1,208 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import LearnSession from './LearnSession'
+import type { Lesson, Manifest, Species } from '../../core/types'
+
+let mockState: Record<string, unknown>
+
+vi.mock('../../store/appStore', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) => selector(mockState),
+}))
+
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({
+      children,
+      ...props
+    }: HTMLAttributes<HTMLDivElement> & {
+      dragConstraints?: unknown
+      dragElastic?: unknown
+      initial?: unknown
+      animate?: unknown
+      exit?: unknown
+      transition?: unknown
+      whileDrag?: unknown
+      onDragEnd?: unknown
+    }) => {
+      const divProps = { ...props }
+      delete divProps.dragConstraints
+      delete divProps.dragElastic
+      delete divProps.initial
+      delete divProps.animate
+      delete divProps.exit
+      delete divProps.transition
+      delete divProps.whileDrag
+      delete divProps.onDragEnd
+
+      return <div {...divProps}>{children}</div>
+    },
+  },
+}))
+
+vi.mock('./BirdCard', () => ({
+  default: ({ species }: { species: Species }) => <div>Bird Card: {species.common_name}</div>,
+}))
+
+vi.mock('./IntroQuiz', () => ({
+  default: ({
+    onBack,
+    onComplete,
+  }: {
+    onBack?: () => void
+    onComplete: (results: Array<{ correct: boolean }>) => void
+  }) => (
+    <div>
+      <p>Intro Quiz</p>
+      {onBack ? <button onClick={onBack}>Back</button> : null}
+      <button onClick={() => onComplete([])}>Finish Quiz</button>
+    </div>
+  ),
+}))
+
+function makeSpecies(id: string): Species {
+  return {
+    id,
+    common_name: id.toUpperCase(),
+    scientific_name: `Genus ${id}`,
+    family: 'TestFamily',
+    ebird_frequency_pct: 50,
+    habitat: ['backyard'],
+    seasonality: 'year-round',
+    mnemonic: `mnemonic for ${id}`,
+    sound_types: { song: 'test song', call: 'test call' },
+    confuser_species: [],
+    confuser_notes: '',
+    audio_clips: {
+      songs: [
+        {
+          xc_id: `${id}-song`,
+          xc_url: '',
+          audio_url: `/${id}.ogg`,
+          type: 'song',
+          quality: 'A',
+          length: '0:10',
+          recordist: 'test',
+          license: 'CC',
+          location: '',
+          country: '',
+          score: 10,
+        },
+      ],
+      calls: [],
+    },
+    photo: {
+      url: `/${id}.jpg`,
+      filename: `${id}.jpg`,
+      source: 'test',
+      license: 'CC',
+      wikipedia_page: '',
+    },
+  }
+}
+
+function makeLesson(lesson: number, speciesIds: string[]): Lesson {
+  return { lesson, title: `Lesson ${lesson}`, species: speciesIds, rationale: 'test' }
+}
+
+function makeManifest(): Manifest {
+  const species = ['a', 'b', 'c', 'd', 'e', 'f'].map(makeSpecies)
+
+  return {
+    version: '1',
+    tier: 1,
+    region: 'test',
+    target_species_count: species.length,
+    curation_date: '2026-04-22',
+    data_sources: {},
+    species,
+    confuser_pairs: [],
+    lesson_plan: {
+      description: 'test',
+      lessons: [
+        makeLesson(1, ['a', 'b', 'c']),
+        makeLesson(2, ['d', 'e', 'f']),
+      ],
+    },
+  }
+}
+
+describe('LearnSession unlock mode', () => {
+  beforeEach(() => {
+    mockState = {
+      manifest: makeManifest(),
+      getIntroducedSpecies: () => ['a', 'b', 'c'].map(id => makeSpecies(id)),
+      introduceSpecies: vi.fn(async () => {}),
+    }
+  })
+
+  it('skips the review warm-up in unlock mode', () => {
+    render(<LearnSession lesson={makeLesson(2, ['d', 'e', 'f'])} mode="unlock" onComplete={() => {}} />)
+
+    expect(screen.queryByText('Quick Review')).not.toBeInTheDocument()
+    expect(screen.getByText('Bird Card: D')).toBeInTheDocument()
+  })
+
+  it('introduces the selected lesson species when an unlock session is completed', async () => {
+    render(<LearnSession lesson={makeLesson(2, ['d', 'e', 'f'])} mode="unlock" onComplete={() => {}} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }))
+    fireEvent.click(screen.getByRole('button', { name: /next/i }))
+    fireEvent.click(screen.getByRole('button', { name: /start quiz/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Finish Quiz' }))
+
+    await waitFor(() => {
+      expect(mockState.introduceSpecies).toHaveBeenCalledWith(['d', 'e', 'f'])
+    })
+
+    expect(screen.getByText('Lesson Complete!')).toBeInTheDocument()
+  })
+})
+
+describe('LearnSession redo mode', () => {
+  beforeEach(() => {
+    mockState = {
+      manifest: makeManifest(),
+      getIntroducedSpecies: () => ['a', 'b', 'c'].map(id => makeSpecies(id)),
+      introduceSpecies: vi.fn(async () => {}),
+    }
+  })
+
+  it('starts on lesson cards instead of warm-up review', () => {
+    render(<LearnSession lesson={makeLesson(2, ['d', 'e', 'f'])} mode="redo" onComplete={() => {}} />)
+
+    expect(screen.queryByText('Quick Review')).not.toBeInTheDocument()
+    expect(screen.getByText('Bird Card: D')).toBeInTheDocument()
+  })
+
+  it('completes redo sessions without introducing species and explains that the schedule stayed unchanged', async () => {
+    render(<LearnSession lesson={makeLesson(2, ['d', 'e', 'f'])} mode="redo" onComplete={() => {}} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }))
+    fireEvent.click(screen.getByRole('button', { name: /next/i }))
+    fireEvent.click(screen.getByRole('button', { name: /start quiz/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Finish Quiz' }))
+
+    await waitFor(() => {
+      expect(mockState.introduceSpecies).not.toHaveBeenCalled()
+    })
+
+    expect(await screen.findByRole('heading', { name: 'Refresher Complete!' })).toBeInTheDocument()
+    expect(screen.getByText('This refresher did not change your review schedule.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Back to Lessons' })).toBeInTheDocument()
+  })
+
+  it('routes quiz Back to lesson exit', () => {
+    const onComplete = vi.fn()
+
+    render(<LearnSession lesson={makeLesson(2, ['d', 'e', 'f'])} mode="redo" onComplete={onComplete} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }))
+    fireEvent.click(screen.getByRole('button', { name: /next/i }))
+    fireEvent.click(screen.getByRole('button', { name: /start quiz/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+})

--- a/beakspeak/src/components/learn/LearnSession.tsx
+++ b/beakspeak/src/components/learn/LearnSession.tsx
@@ -8,19 +8,21 @@ import BirdCard from './BirdCard'
 import IntroQuiz from './IntroQuiz'
 
 type Phase = 'review' | 'cards' | 'quiz' | 'complete'
+type LearnSessionMode = 'normal' | 'unlock' | 'redo'
 
 interface Props {
   lesson: Lesson
+  mode?: LearnSessionMode
   onComplete: () => void
 }
 
-export default function LearnSession({ lesson, onComplete }: Props) {
+export default function LearnSession({ lesson, mode = 'normal', onComplete }: Props) {
   const manifest = useAppStore(s => s.manifest)
   const getIntroducedSpecies = useAppStore(s => s.getIntroducedSpecies)
   const introduceSpecies = useAppStore(s => s.introduceSpecies)
 
   const introducedSpecies = getIntroducedSpecies()
-  const hasReviewPhase = introducedSpecies.length >= 3
+  const hasReviewPhase = mode === 'normal' && introducedSpecies.length >= 3
 
   const [phase, setPhase] = useState<Phase>(hasReviewPhase ? 'review' : 'cards')
   const [cardIndex, setCardIndex] = useState(0)
@@ -45,9 +47,11 @@ export default function LearnSession({ lesson, onComplete }: Props) {
   }, [cardIndex])
 
   const handleQuizComplete = useCallback(async () => {
-    await introduceSpecies(lesson.species)
+    if (mode !== 'redo') {
+      await introduceSpecies(lesson.species)
+    }
     setPhase('complete')
-  }, [introduceSpecies, lesson.species])
+  }, [introduceSpecies, lesson.species, mode])
 
   const handleReviewComplete = useCallback(() => {
     setPhase('cards')
@@ -68,7 +72,7 @@ export default function LearnSession({ lesson, onComplete }: Props) {
           <p className="text-sm text-secondary font-medium">Quick Review</p>
           <p className="text-xs text-text-muted">Let's warm up with some familiar birds</p>
         </div>
-        <IntroQuiz items={reviewItems} onComplete={handleReviewComplete} />
+        <IntroQuiz items={reviewItems} onComplete={handleReviewComplete} onBack={onComplete} />
       </div>
     )
   }
@@ -159,7 +163,7 @@ export default function LearnSession({ lesson, onComplete }: Props) {
           <p className="text-sm text-primary font-medium">Quick Quiz</p>
           <p className="text-xs text-text-muted">Test what you just learned!</p>
         </div>
-        <IntroQuiz items={quizItems} onComplete={handleQuizComplete} />
+        <IntroQuiz items={quizItems} onComplete={handleQuizComplete} onBack={onComplete} />
       </div>
     )
   }
@@ -168,18 +172,33 @@ export default function LearnSession({ lesson, onComplete }: Props) {
   return (
     <div className="flex flex-1 flex-col items-center justify-center p-6 text-center">
       <p className="text-4xl mb-4">🎉</p>
-      <h2 className="text-xl font-semibold text-text mb-2">Lesson Complete!</h2>
-      <p className="text-text-muted mb-2">
-        You've learned {lessonSpecies.map(s => s.common_name).join(', ')}
-      </p>
-      <p className="text-sm text-text-muted mb-6">
-        They'll appear in your review sessions soon.
-      </p>
+      <h2 className="text-xl font-semibold text-text mb-2">
+        {mode === 'redo' ? 'Refresher Complete!' : 'Lesson Complete!'}
+      </h2>
+      {mode === 'redo' ? (
+        <>
+          <p className="text-text-muted mb-2">
+            You revisited {lessonSpecies.map(s => s.common_name).join(', ')}.
+          </p>
+          <p className="text-sm text-text-muted mb-6">
+            This refresher did not change your review schedule.
+          </p>
+        </>
+      ) : (
+        <>
+          <p className="text-text-muted mb-2">
+            You've learned {lessonSpecies.map(s => s.common_name).join(', ')}
+          </p>
+          <p className="text-sm text-text-muted mb-6">
+            They'll appear in your review sessions soon.
+          </p>
+        </>
+      )}
       <button
         onClick={onComplete}
         className="px-6 py-3 bg-primary text-white rounded-full font-medium"
       >
-        Continue
+        {mode === 'redo' ? 'Back to Lessons' : 'Continue'}
       </button>
     </div>
   )

--- a/beakspeak/src/components/learn/LearnTab.test.tsx
+++ b/beakspeak/src/components/learn/LearnTab.test.tsx
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import LearnTab from './LearnTab'
+import type { Lesson, Manifest, Species, UserProgress } from '../../core/types'
+
+const { learnSessionMock } = vi.hoisted(() => ({
+  learnSessionMock: vi.fn(({ lesson, mode, onComplete }: { lesson: Lesson; mode?: string; onComplete?: () => void }) => (
+    <div data-testid="learn-session">
+      {lesson.title}::{mode ?? 'normal'}
+      <button onClick={onComplete}>Exit Session</button>
+    </div>
+  )),
+}))
+
+let mockState: Record<string, unknown>
+
+vi.mock('../../store/appStore', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) => selector(mockState),
+}))
+
+vi.mock('./LearnSession', () => ({
+  default: (props: { lesson: Lesson; mode?: string; onComplete?: () => void }) => learnSessionMock(props),
+}))
+
+function makeSpecies(id: string): Species {
+  return {
+    id,
+    common_name: id.toUpperCase(),
+    scientific_name: `Genus ${id}`,
+    family: 'TestFamily',
+    ebird_frequency_pct: 50,
+    habitat: ['backyard'],
+    seasonality: 'year-round',
+    mnemonic: `mnemonic for ${id}`,
+    sound_types: { song: 'test song', call: 'test call' },
+    confuser_species: [],
+    confuser_notes: '',
+    audio_clips: {
+      songs: [
+        {
+          xc_id: `${id}-song`,
+          xc_url: '',
+          audio_url: `/${id}.ogg`,
+          type: 'song',
+          quality: 'A',
+          length: '0:10',
+          recordist: 'test',
+          license: 'CC',
+          location: '',
+          country: '',
+          score: 10,
+        },
+      ],
+      calls: [],
+    },
+    photo: {
+      url: `/${id}.jpg`,
+      filename: `${id}.jpg`,
+      source: 'test',
+      license: 'CC',
+      wikipedia_page: '',
+    },
+  }
+}
+
+function makeLesson(lesson: number, speciesIds: string[]): Lesson {
+  return { lesson, title: `Lesson ${lesson}`, species: speciesIds, rationale: 'test' }
+}
+
+function makeManifest(): Manifest {
+  const species = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'].map(makeSpecies)
+
+  return {
+    version: '1',
+    tier: 1,
+    region: 'test',
+    target_species_count: species.length,
+    curation_date: '2026-04-22',
+    data_sources: {},
+    species,
+    confuser_pairs: [],
+    lesson_plan: {
+      description: 'test',
+      lessons: [
+        makeLesson(1, ['a', 'b', 'c']),
+        makeLesson(2, ['d', 'e', 'f']),
+        makeLesson(3, ['g', 'h', 'i']),
+      ],
+    },
+  }
+}
+
+function makeProgress(speciesId: string, overrides: Partial<UserProgress> = {}): UserProgress {
+  return {
+    speciesId,
+    introduced: false,
+    stability: 0,
+    difficulty: 0,
+    elapsedDays: 0,
+    scheduledDays: 0,
+    reps: 0,
+    lapses: 0,
+    state: 'new',
+    ...overrides,
+  }
+}
+
+function makeStoreState(progressEntries: Array<[string, UserProgress]> = []) {
+  const manifest = makeManifest()
+  const allProgress = new Map<string, UserProgress>(progressEntries)
+  const introduceSpecies = vi.fn(async (speciesIds: string[]) => {
+    const updated = new Map(allProgress)
+    const now = Date.now()
+
+    for (const speciesId of speciesIds) {
+      const existing = updated.get(speciesId)
+      updated.set(
+        speciesId,
+        existing
+          ? { ...existing, introduced: true, introducedAt: existing.introducedAt ?? now }
+          : makeProgress(speciesId, { introduced: true, introducedAt: now }),
+      )
+    }
+
+    mockState = { ...mockState, allProgress: updated }
+  })
+
+  return {
+    manifest,
+    allProgress,
+    introduceSpecies,
+    getCompletedLessons: () =>
+      manifest.lesson_plan.lessons
+        .filter(lesson =>
+          lesson.species.every(
+            speciesId => (mockState.allProgress as Map<string, UserProgress>).get(speciesId)?.introduced,
+          ),
+        )
+        .map(lesson => lesson.lesson),
+    getIntroducedSpecies: () =>
+      manifest.species.filter(
+        species => (mockState.allProgress as Map<string, UserProgress>).get(species.id)?.introduced,
+      ),
+  }
+}
+
+describe('LearnTab locked lesson dialog', () => {
+  beforeEach(() => {
+    learnSessionMock.mockClear()
+    mockState = makeStoreState()
+  })
+
+  it('opens a dialog when a locked lesson is clicked', () => {
+    render(<LearnTab />)
+
+    fireEvent.click(screen.getByRole('button', { name: /lesson 2: lesson 2/i }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('Take It Step by Step')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Skip Ahead Anyway' })).toBeInTheDocument()
+  })
+
+  it('uses relearning framing when relearning and prerequisite locks both apply', () => {
+    mockState = makeStoreState([
+      ['x', makeProgress('x', { introduced: true, state: 'relearning' })],
+    ])
+
+    render(<LearnTab />)
+
+    fireEvent.click(screen.getByRole('button', { name: /lesson 2: lesson 2/i }))
+
+    expect(screen.getByText('Practice First')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Open Lesson Anyway' })).toBeInTheDocument()
+    expect(screen.queryByText('Take It Step by Step')).not.toBeInTheDocument()
+  })
+
+  it('closes the dialog when Never mind is clicked', () => {
+    render(<LearnTab />)
+
+    fireEvent.click(screen.getByRole('button', { name: /lesson 2: lesson 2/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Never mind' }))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('closes the dialog when the backdrop is clicked', () => {
+    render(<LearnTab />)
+
+    fireEvent.click(screen.getByRole('button', { name: /lesson 2: lesson 2/i }))
+    fireEvent.click(screen.getByTestId('unlock-dialog-backdrop'))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('launches a completed lesson in redo mode', () => {
+    mockState = makeStoreState([
+      ['a', makeProgress('a', { introduced: true })],
+      ['b', makeProgress('b', { introduced: true })],
+      ['c', makeProgress('c', { introduced: true })],
+    ])
+
+    render(<LearnTab />)
+
+    fireEvent.click(screen.getByRole('button', { name: /lesson 1: lesson 1/i }))
+
+    expect(screen.getByTestId('learn-session')).toHaveTextContent('Lesson 1::redo')
+  })
+
+  it('allows completed lessons to relaunch during relearning', () => {
+    mockState = makeStoreState([
+      ['a', makeProgress('a', { introduced: true })],
+      ['b', makeProgress('b', { introduced: true })],
+      ['c', makeProgress('c', { introduced: true })],
+      ['x', makeProgress('x', { introduced: true, state: 'relearning' })],
+    ])
+
+    render(<LearnTab />)
+
+    fireEvent.click(screen.getByRole('button', { name: /lesson 1: lesson 1/i }))
+
+    expect(screen.getByTestId('learn-session')).toHaveTextContent('Lesson 1::redo')
+  })
+
+  it('confirms a locked lesson by introducing skipped lessons and launching unlock mode', async () => {
+    mockState = makeStoreState([
+      ['a', makeProgress('a', { introduced: true })],
+      ['b', makeProgress('b', { introduced: true })],
+      ['c', makeProgress('c', { introduced: true })],
+      ['e', makeProgress('e', {
+        introduced: true,
+        introducedAt: 123,
+        reps: 5,
+        state: 'review',
+        scheduledDays: 10,
+        elapsedDays: 3,
+      })],
+    ])
+
+    render(<LearnTab />)
+
+    fireEvent.click(screen.getByRole('button', { name: /lesson 3: lesson 3/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Skip Ahead Anyway' }))
+
+    await waitFor(() => {
+      expect((mockState.introduceSpecies as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(['d', 'e', 'f'])
+    })
+
+    expect(screen.getByTestId('learn-session')).toHaveTextContent('Lesson 3::unlock')
+
+    const progress = mockState.allProgress as Map<string, UserProgress>
+    expect(progress.get('d')?.introduced).toBe(true)
+    expect(progress.get('f')?.introduced).toBe(true)
+    expect(progress.get('e')).toMatchObject({
+      introduced: true,
+      introducedAt: 123,
+      reps: 5,
+      state: 'review',
+      scheduledDays: 10,
+      elapsedDays: 3,
+    })
+    expect((mockState.introduceSpecies as ReturnType<typeof vi.fn>).mock.calls[0][0]).not.toContain('g')
+  })
+
+  it('requires confirmation again after backing out of an unlock launch when relearning still applies', async () => {
+    mockState = makeStoreState([
+      ['a', makeProgress('a', { introduced: true })],
+      ['b', makeProgress('b', { introduced: true })],
+      ['c', makeProgress('c', { introduced: true })],
+      ['x', makeProgress('x', { introduced: true, state: 'relearning' })],
+    ])
+
+    render(<LearnTab />)
+
+    fireEvent.click(screen.getByRole('button', { name: /lesson 3: lesson 3/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Open Lesson Anyway' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('learn-session')).toHaveTextContent('Lesson 3::unlock')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Exit Session' }))
+    fireEvent.click(screen.getByRole('button', { name: /lesson 3: lesson 3/i }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.queryByTestId('learn-session')).not.toBeInTheDocument()
+  })
+})

--- a/beakspeak/src/components/learn/LearnTab.tsx
+++ b/beakspeak/src/components/learn/LearnTab.tsx
@@ -1,29 +1,54 @@
 import { useState } from 'react'
 import { useAppStore } from '../../store/appStore'
 import { getLessons } from '../../core/manifest'
-import { isLessonAvailable, isLessonComplete } from '../../core/lesson'
+import { getLessonLockReason, isLessonComplete } from '../../core/lesson'
 import { getSpeciesByIds } from '../../core/manifest'
 import LearnSession from './LearnSession'
 import type { Lesson } from '../../core/types'
+import UnlockDialog from './UnlockDialog'
+
+type LearnLaunch = {
+  lesson: Lesson
+  mode: 'normal' | 'unlock' | 'redo'
+}
+
+function getSkippedLessonsForUnlock(
+  lessons: Lesson[],
+  targetLesson: Lesson,
+  completedLessonNums: number[],
+): Lesson[] {
+  const completedLessons = new Set(completedLessonNums)
+
+  return lessons.filter(lesson => lesson.lesson < targetLesson.lesson && !completedLessons.has(lesson.lesson))
+}
 
 export default function LearnTab() {
   const manifest = useAppStore(s => s.manifest)
   const allProgress = useAppStore(s => s.allProgress)
   const getCompletedLessons = useAppStore(s => s.getCompletedLessons)
   const getIntroducedSpecies = useAppStore(s => s.getIntroducedSpecies)
-  const [activeLesson, setActiveLesson] = useState<Lesson | null>(null)
+  const introduceSpecies = useAppStore(s => s.introduceSpecies)
+  const [activeLaunch, setActiveLaunch] = useState<LearnLaunch | null>(null)
+  const [unlockLesson, setUnlockLesson] = useState<Lesson | null>(null)
 
   if (!manifest) return null
 
   const lessons = getLessons(manifest)
   const completedLessons = getCompletedLessons()
   const introducedCount = getIntroducedSpecies().length
+  const unlockReason = unlockLesson
+    ? getLessonLockReason(unlockLesson.lesson, completedLessons, allProgress)
+    : null
+  const skippedLessons = unlockLesson
+    ? getSkippedLessonsForUnlock(lessons, unlockLesson, completedLessons)
+    : []
 
-  if (activeLesson) {
+  if (activeLaunch) {
     return (
       <LearnSession
-        lesson={activeLesson}
-        onComplete={() => setActiveLesson(null)}
+        lesson={activeLaunch.lesson}
+        mode={activeLaunch.mode}
+        onComplete={() => setActiveLaunch(null)}
       />
     )
   }
@@ -45,21 +70,31 @@ export default function LearnTab() {
 
       <div className="space-y-3">
         {lessons.map(lesson => {
-          const available = isLessonAvailable(lesson.lesson, completedLessons, allProgress)
+          const lockReason = getLessonLockReason(lesson.lesson, completedLessons, allProgress)
+          const available = lockReason === null
           const completed = isLessonComplete(lesson, allProgress)
           const species = getSpeciesByIds(manifest, lesson.species)
 
           return (
             <button
               key={lesson.lesson}
-              onClick={() => available && !completed && setActiveLesson(lesson)}
-              disabled={!available || completed}
+              onClick={() => {
+                if (completed) {
+                  setActiveLaunch({ lesson, mode: 'redo' })
+                  return
+                }
+                if (available) {
+                  setActiveLaunch({ lesson, mode: 'normal' })
+                  return
+                }
+                setUnlockLesson(lesson)
+              }}
               className={`w-full text-left p-4 rounded-xl border transition-all ${
                 completed
                   ? 'bg-success/10 border-success/30'
                   : available
                   ? 'bg-card border-border hover:border-primary active:border-primary active:scale-[0.98] active:bg-primary/5 cursor-pointer'
-                  : 'bg-border/30 border-border/50 opacity-60'
+                  : 'bg-border/30 border-border/50 opacity-60 hover:border-primary/40 active:scale-[0.98] cursor-pointer'
               }`}
             >
               <div className="flex items-center justify-between mb-2">
@@ -89,6 +124,20 @@ export default function LearnTab() {
           )
         })}
       </div>
+
+      {unlockLesson && unlockReason && (
+        <UnlockDialog
+          lesson={unlockLesson}
+          lockReason={unlockReason}
+          onConfirm={async () => {
+            await introduceSpecies(skippedLessons.flatMap(lesson => lesson.species))
+            setUnlockLesson(null)
+            setActiveLaunch({ lesson: unlockLesson, mode: 'unlock' })
+          }}
+          onDismiss={() => setUnlockLesson(null)}
+          skippedLessons={skippedLessons}
+        />
+      )}
     </div>
   )
 }

--- a/beakspeak/src/components/learn/UnlockDialog.tsx
+++ b/beakspeak/src/components/learn/UnlockDialog.tsx
@@ -1,0 +1,65 @@
+import type { LessonLockReason } from '../../core/lesson'
+import type { Lesson } from '../../core/types'
+import { getUnlockConsequenceCopy } from './unlockConsequenceCopy'
+
+interface Props {
+  lesson: Lesson
+  lockReason: LessonLockReason
+  skippedLessons: Lesson[]
+  onConfirm: () => void
+  onDismiss: () => void
+}
+
+export default function UnlockDialog({
+  lesson,
+  lockReason,
+  skippedLessons,
+  onConfirm,
+  onDismiss,
+}: Props) {
+  const title = lockReason.type === 'relearning' ? 'Practice First' : 'Take It Step by Step'
+  const confirmLabel = lockReason.type === 'relearning' ? 'Open Lesson Anyway' : 'Skip Ahead Anyway'
+  const explanation =
+    lockReason.type === 'relearning'
+      ? 'You already have birds in relearning. Opening a new lesson now can make those mix-ups harder to untangle.'
+      : 'This lesson is still locked because the guided path expects you to finish the earlier lesson first.'
+  const consequence = getUnlockConsequenceCopy(skippedLessons, lesson.lesson)
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end bg-black/50 p-4 sm:items-center sm:justify-center"
+      data-testid="unlock-dialog-backdrop"
+      onClick={onDismiss}
+    >
+      <div
+        aria-labelledby="unlock-dialog-title"
+        aria-modal="true"
+        className="w-full max-w-md rounded-3xl border border-border bg-bg p-6 shadow-xl"
+        role="dialog"
+        onClick={event => event.stopPropagation()}
+      >
+        <p className="mb-2 text-sm font-medium text-primary">Lesson {lesson.lesson}</p>
+        <h2 className="mb-3 text-2xl font-semibold text-text" id="unlock-dialog-title">
+          {title}
+        </h2>
+        <p className="mb-3 text-sm leading-6 text-text">{explanation}</p>
+        <p className="mb-6 text-sm leading-6 text-text-muted">{consequence}</p>
+
+        <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <button
+            className="rounded-full border border-border px-5 py-3 text-sm font-medium text-text"
+            onClick={onDismiss}
+          >
+            Never mind
+          </button>
+          <button
+            className="rounded-full bg-primary px-5 py-3 text-sm font-medium text-white"
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/beakspeak/src/components/learn/unlockConsequenceCopy.ts
+++ b/beakspeak/src/components/learn/unlockConsequenceCopy.ts
@@ -1,0 +1,30 @@
+import type { Lesson } from '../../core/types'
+
+function formatSkippedLessonLabel(skippedLessons: Lesson[]): string {
+  const lessonNumbers = skippedLessons.map(lesson => lesson.lesson)
+
+  if (lessonNumbers.length === 1) {
+    return `Lesson ${lessonNumbers[0]}`
+  }
+
+  if (lessonNumbers.length === 2) {
+    return `Lessons ${lessonNumbers[0]} and ${lessonNumbers[1]}`
+  }
+
+  if (lessonNumbers.length === 3) {
+    return `Lessons ${lessonNumbers[0]}, ${lessonNumbers[1]}, and ${lessonNumbers[2]}`
+  }
+
+  return `Lessons ${lessonNumbers[0]}-${lessonNumbers[lessonNumbers.length - 1]}`
+}
+
+export function getUnlockConsequenceCopy(skippedLessons: Lesson[], selectedLessonNum: number): string {
+  if (skippedLessons.length === 0) {
+    return `This will open Lesson ${selectedLessonNum} now. Nothing will be marked learned unless you finish the lesson.`
+  }
+
+  const birdCount = skippedLessons.reduce((count, lesson) => count + lesson.species.length, 0)
+  const birdLabel = `${birdCount} ${birdCount === 1 ? 'bird' : 'birds'}`
+
+  return `${formatSkippedLessonLabel(skippedLessons)} will be marked learned now, so those ${birdLabel} will start showing up in your reviews.`
+}

--- a/beakspeak/src/components/quiz/QuizResult.tsx
+++ b/beakspeak/src/components/quiz/QuizResult.tsx
@@ -8,10 +8,11 @@ interface QuizAnswer {
 
 interface Props {
   answers: QuizAnswer[]
+  mode: 'review' | 'practice'
   onDone: () => void
 }
 
-export default function QuizResult({ answers, onDone }: Props) {
+export default function QuizResult({ answers, mode, onDone }: Props) {
   const correctCount = answers.filter(a => a.correct).length
   const total = answers.length
   const needsPractice = answers.filter(a => !a.correct)
@@ -30,6 +31,11 @@ export default function QuizResult({ answers, onDone }: Props) {
         <p className="text-text-muted">
           {percentage}% correct
         </p>
+        {mode === 'practice' && (
+          <p className="text-sm text-text-muted mt-2">
+            This practice session didn&apos;t change your review schedule.
+          </p>
+        )}
       </div>
 
       {needsPractice.length > 0 && (

--- a/beakspeak/src/components/quiz/QuizSession.test.tsx
+++ b/beakspeak/src/components/quiz/QuizSession.test.tsx
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import QuizSession from './QuizSession'
+import type { Manifest, QuizItem, Species } from '../../core/types'
+
+const { buildQuizSessionMock } = vi.hoisted(() => ({
+  buildQuizSessionMock: vi.fn(),
+}))
+
+let mockState: Record<string, unknown>
+
+vi.mock('../../store/appStore', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) => selector(mockState),
+}))
+
+vi.mock('../../core/quiz', () => ({
+  buildQuizSession: (...args: unknown[]) => buildQuizSessionMock(...args),
+}))
+
+vi.mock('./ThreeChoiceQuiz', () => ({
+  default: ({ onAnswer }: { onAnswer: (correct: boolean, responseTimeMs: number) => void }) => (
+    <button onClick={() => onAnswer(false, 1200)}>Answer Question</button>
+  ),
+}))
+
+function makeSpecies(id: string): Species {
+  return {
+    id,
+    common_name: id.toUpperCase(),
+    scientific_name: `Genus ${id}`,
+    family: 'TestFamily',
+    ebird_frequency_pct: 50,
+    habitat: ['backyard'],
+    seasonality: 'year-round',
+    mnemonic: `mnemonic for ${id}`,
+    sound_types: { song: 'test song', call: 'test call' },
+    confuser_species: [],
+    confuser_notes: '',
+    audio_clips: {
+      songs: [
+        {
+          xc_id: `${id}-song`,
+          xc_url: '',
+          audio_url: `/${id}.ogg`,
+          type: 'song',
+          quality: 'A',
+          length: '0:10',
+          recordist: 'test',
+          license: 'CC',
+          location: '',
+          country: '',
+          score: 10,
+        },
+      ],
+      calls: [],
+    },
+    photo: {
+      url: `/${id}.jpg`,
+      filename: `${id}.jpg`,
+      source: 'test',
+      license: 'CC',
+      wikipedia_page: '',
+    },
+  }
+}
+
+function makeManifest(): Manifest {
+  return {
+    version: '1',
+    tier: 1,
+    region: 'test',
+    target_species_count: 3,
+    curation_date: '2026-04-22',
+    data_sources: {},
+    species: ['a', 'b', 'c'].map(makeSpecies),
+    confuser_pairs: [],
+    lesson_plan: {
+      description: 'test',
+      lessons: [],
+    },
+  }
+}
+
+function makeQuizItem(): QuizItem {
+  const target = makeSpecies('a')
+  return {
+    targetSpecies: target,
+    exerciseType: 'three_choice',
+    clip: target.audio_clips.songs[0],
+    choices: [target, makeSpecies('b'), makeSpecies('c')],
+  }
+}
+
+describe('QuizSession practice mode', () => {
+  beforeEach(() => {
+    buildQuizSessionMock.mockReset()
+    buildQuizSessionMock.mockReturnValue([makeQuizItem()])
+
+    mockState = {
+      manifest: makeManifest(),
+      allProgress: new Map(),
+      lastPlayedClipId: new Map(),
+      updateProgress: vi.fn(),
+      logConfusion: vi.fn(),
+    }
+  })
+
+  it('labels practice sessions and keeps them side-effect free', () => {
+    render(<QuizSession mode="practice" onComplete={vi.fn()} />)
+
+    expect(screen.getByText('Practice Session')).toBeInTheDocument()
+    expect(screen.getByText("This won't change your review schedule")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Answer Question' }))
+
+    expect(mockState.updateProgress).not.toHaveBeenCalled()
+    expect(mockState.logConfusion).not.toHaveBeenCalled()
+    expect(screen.getByText('Needs More Practice')).toBeInTheDocument()
+    expect(screen.getByText(/didn’t change your review schedule|didn't change your review schedule/i)).toBeInTheDocument()
+  })
+})

--- a/beakspeak/src/components/quiz/QuizSession.tsx
+++ b/beakspeak/src/components/quiz/QuizSession.tsx
@@ -9,6 +9,7 @@ import QuizResult from './QuizResult'
 import type { Species } from '../../core/types'
 
 interface Props {
+  mode: 'review' | 'practice'
   onComplete: () => void
 }
 
@@ -18,7 +19,7 @@ interface QuizAnswer {
   rating: number
 }
 
-export default function QuizSession({ onComplete }: Props) {
+export default function QuizSession({ mode, onComplete }: Props) {
   const manifest = useAppStore(s => s.manifest)
   const allProgress = useAppStore(s => s.allProgress)
   const lastPlayedClipId = useAppStore(s => s.lastPlayedClipId)
@@ -41,16 +42,14 @@ export default function QuizSession({ onComplete }: Props) {
     const exerciseType = item.exerciseType
     const rating = ratingFromOutcome(correct, responseTimeMs, exerciseType)
 
-    // Update SRS
-    const existingProgress = allProgress.get(item.targetSpecies.id) ?? createNewProgress(item.targetSpecies.id)
-    const updated = scheduleReview({ ...existingProgress, introduced: true }, rating)
-    await updateProgress(item.targetSpecies.id, updated)
+    if (mode === 'review') {
+      const existingProgress = allProgress.get(item.targetSpecies.id) ?? createNewProgress(item.targetSpecies.id)
+      const updated = scheduleReview({ ...existingProgress, introduced: true }, rating)
+      await updateProgress(item.targetSpecies.id, updated)
 
-    // Log confusion if incorrect
-    if (!correct) {
-      // For three_choice, we don't know which species was selected here
-      // but we can log the target as needing practice
-      await logConfusion(item.targetSpecies.id, 'unknown')
+      if (!correct) {
+        await logConfusion(item.targetSpecies.id, 'unknown')
+      }
     }
 
     setAnswers(prev => [...prev, { species: item.targetSpecies, correct, rating }])
@@ -60,7 +59,7 @@ export default function QuizSession({ onComplete }: Props) {
     } else {
       setCurrentIndex(prev => prev + 1)
     }
-  }, [items, currentIndex, allProgress, updateProgress, logConfusion])
+  }, [items, currentIndex, allProgress, updateProgress, logConfusion, mode])
 
   if (!manifest || items.length === 0) {
     return (
@@ -74,7 +73,7 @@ export default function QuizSession({ onComplete }: Props) {
   }
 
   if (showResults) {
-    return <QuizResult answers={answers} onDone={onComplete} />
+    return <QuizResult answers={answers} mode={mode} onDone={onComplete} />
   }
 
   const currentItem = items[currentIndex]
@@ -87,6 +86,12 @@ export default function QuizSession({ onComplete }: Props) {
           {currentIndex + 1} / {items.length}
         </p>
       </div>
+      {mode === 'practice' && (
+        <div className="px-4 pb-4 text-center">
+          <p className="text-sm font-medium text-primary">Practice Session</p>
+          <p className="text-xs text-text-muted">This won&apos;t change your review schedule</p>
+        </div>
+      )}
       <div className="flex-1">
         {currentItem.exerciseType === 'three_choice' ? (
           <ThreeChoiceQuiz

--- a/beakspeak/src/components/quiz/QuizTab.test.tsx
+++ b/beakspeak/src/components/quiz/QuizTab.test.tsx
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import QuizTab from './QuizTab'
+import type { Lesson, Manifest, Species } from '../../core/types'
+
+const { quizSessionMock } = vi.hoisted(() => ({
+  quizSessionMock: vi.fn(({ mode }: { mode: 'review' | 'practice' }) => (
+    <div data-testid="quiz-session">{mode}</div>
+  )),
+}))
+
+let mockState: Record<string, unknown>
+
+vi.mock('../../store/appStore', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) => selector(mockState),
+}))
+
+vi.mock('./QuizSession', () => ({
+  default: (props: { mode: 'review' | 'practice' }) => quizSessionMock(props),
+}))
+
+function makeSpecies(id: string): Species {
+  return {
+    id,
+    common_name: id.toUpperCase(),
+    scientific_name: `Genus ${id}`,
+    family: 'TestFamily',
+    ebird_frequency_pct: 50,
+    habitat: ['backyard'],
+    seasonality: 'year-round',
+    mnemonic: `mnemonic for ${id}`,
+    sound_types: { song: 'test song', call: 'test call' },
+    confuser_species: [],
+    confuser_notes: '',
+    audio_clips: {
+      songs: [
+        {
+          xc_id: `${id}-song`,
+          xc_url: '',
+          audio_url: `/${id}.ogg`,
+          type: 'song',
+          quality: 'A',
+          length: '0:10',
+          recordist: 'test',
+          license: 'CC',
+          location: '',
+          country: '',
+          score: 10,
+        },
+      ],
+      calls: [],
+    },
+    photo: {
+      url: `/${id}.jpg`,
+      filename: `${id}.jpg`,
+      source: 'test',
+      license: 'CC',
+      wikipedia_page: '',
+    },
+  }
+}
+
+function makeLesson(lesson: number, speciesIds: string[]): Lesson {
+  return { lesson, title: `Lesson ${lesson}`, species: speciesIds, rationale: 'test' }
+}
+
+function makeManifest(): Manifest {
+  const species = ['a', 'b', 'c', 'd', 'e', 'f'].map(makeSpecies)
+
+  return {
+    version: '1',
+    tier: 1,
+    region: 'test',
+    target_species_count: species.length,
+    curation_date: '2026-04-22',
+    data_sources: {},
+    species,
+    confuser_pairs: [],
+    lesson_plan: {
+      description: 'test',
+      lessons: [
+        makeLesson(1, ['a', 'b', 'c']),
+        makeLesson(2, ['d', 'e', 'f']),
+      ],
+    },
+  }
+}
+
+describe('QuizTab practice entry', () => {
+  beforeEach(() => {
+    quizSessionMock.mockClear()
+    mockState = {
+      manifest: makeManifest(),
+      allProgress: new Map(),
+      getIntroducedSpecies: () => ['a', 'b', 'c'].map(makeSpecies),
+      getDueForReview: () => [],
+      hasRelearning: () => false,
+      getCompletedLessons: () => [1],
+      setTab: vi.fn(),
+    }
+  })
+
+  it('offers practice as a secondary action when learning is still available', () => {
+    render(<QuizTab />)
+
+    expect(screen.getByRole('button', { name: 'Learn More Birds' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Practice Anyway' }))
+
+    expect(screen.getByTestId('quiz-session')).toHaveTextContent('practice')
+  })
+
+  it('offers practice as the only action when relearning blocks learning', () => {
+    mockState = {
+      ...mockState,
+      hasRelearning: () => true,
+    }
+
+    render(<QuizTab />)
+
+    expect(screen.getByText("Some birds need more practice. Come back when they're due.")).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Learn More Birds' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Practice Anyway' }))
+
+    expect(screen.getByTestId('quiz-session')).toHaveTextContent('practice')
+  })
+
+  it('does not offer practice when birds are due for review', () => {
+    mockState = {
+      ...mockState,
+      getDueForReview: () => [{ speciesId: 'a' }],
+    }
+
+    render(<QuizTab />)
+
+    expect(screen.getByRole('button', { name: 'Start Review' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Practice Anyway' })).not.toBeInTheDocument()
+  })
+
+  it('does not offer practice when fewer than three birds are introduced', () => {
+    mockState = {
+      ...mockState,
+      getIntroducedSpecies: () => ['a', 'b'].map(makeSpecies),
+    }
+
+    render(<QuizTab />)
+
+    expect(screen.getByRole('button', { name: 'Learn More Birds' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Practice Anyway' })).not.toBeInTheDocument()
+  })
+
+  it('offers practice as the only action when all lessons are complete', () => {
+    mockState = {
+      ...mockState,
+      getCompletedLessons: () => [1, 2],
+    }
+
+    render(<QuizTab />)
+
+    expect(screen.getByRole('button', { name: 'Practice Anyway' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Learn More Birds' })).not.toBeInTheDocument()
+  })
+})

--- a/beakspeak/src/components/quiz/QuizTab.tsx
+++ b/beakspeak/src/components/quiz/QuizTab.tsx
@@ -1,20 +1,34 @@
 import { useState } from 'react'
+import { getLessons } from '../../core/manifest'
+import { getNextLesson, isLessonAvailable } from '../../core/lesson'
 import { useAppStore } from '../../store/appStore'
 import QuizSession from './QuizSession'
 
 export default function QuizTab() {
+  const manifest = useAppStore(s => s.manifest)
+  const allProgress = useAppStore(s => s.allProgress)
+  const getCompletedLessons = useAppStore(s => s.getCompletedLessons)
   const getIntroducedSpecies = useAppStore(s => s.getIntroducedSpecies)
   const getDueForReview = useAppStore(s => s.getDueForReview)
   const hasRelearning = useAppStore(s => s.hasRelearning)
   const setTab = useAppStore(s => s.setTab)
-  const [inSession, setInSession] = useState(false)
+  const [sessionMode, setSessionMode] = useState<'review' | 'practice' | null>(null)
+
+  if (!manifest) return null
 
   const introduced = getIntroducedSpecies()
   const dueForReview = getDueForReview()
   const relearning = hasRelearning()
+  const completedLessons = getCompletedLessons()
+  const lessons = getLessons(manifest)
+  const nextLesson = getNextLesson(lessons, completedLessons)
+  const allLessonsComplete = nextLesson === null
+  const guidedPathAvailable = nextLesson !== null
+    && isLessonAvailable(nextLesson.lesson, completedLessons, allProgress)
+  const practiceAvailable = introduced.length >= 3 && dueForReview.length === 0
 
-  if (inSession) {
-    return <QuizSession onComplete={() => setInSession(false)} />
+  if (sessionMode) {
+    return <QuizSession mode={sessionMode} onComplete={() => setSessionMode(null)} />
   }
 
   if (introduced.length === 0) {
@@ -44,7 +58,7 @@ export default function QuizTab() {
             {dueForReview.length} bird{dueForReview.length !== 1 ? 's' : ''} due for review
           </p>
           <button
-            onClick={() => setInSession(true)}
+            onClick={() => setSessionMode('review')}
             className="px-6 py-3 bg-primary text-white rounded-full font-medium"
           >
             Start Review
@@ -54,17 +68,53 @@ export default function QuizTab() {
         <>
           <p className="text-text-muted mb-4">No birds due for review right now.</p>
           {relearning ? (
-            <p className="text-sm text-error/80">
-              Some birds need more practice. Come back when they're due.
-            </p>
-          ) : (
+            <div className="flex flex-col items-center gap-3">
+              <p className="text-sm text-error/80">
+                Some birds need more practice. Come back when they're due.
+              </p>
+              {practiceAvailable && (
+                <button
+                  onClick={() => setSessionMode('practice')}
+                  className="px-6 py-3 bg-primary text-white rounded-full font-medium"
+                >
+                  Practice Anyway
+                </button>
+              )}
+            </div>
+          ) : allLessonsComplete ? (
+            practiceAvailable ? (
+              <button
+                onClick={() => setSessionMode('practice')}
+                className="px-6 py-3 bg-primary text-white rounded-full font-medium"
+              >
+                Practice Anyway
+              </button>
+            ) : null
+          ) : guidedPathAvailable ? (
+            <div className="flex flex-col items-center gap-3">
+              <button
+                onClick={() => setTab('learn')}
+                className="px-6 py-3 bg-secondary text-white rounded-full font-medium"
+              >
+                Learn More Birds
+              </button>
+              {practiceAvailable && (
+                <button
+                  onClick={() => setSessionMode('practice')}
+                  className="text-sm font-medium text-primary underline underline-offset-4"
+                >
+                  Practice Anyway
+                </button>
+              )}
+            </div>
+          ) : practiceAvailable ? (
             <button
-              onClick={() => setTab('learn')}
-              className="px-6 py-3 bg-secondary text-white rounded-full font-medium"
+              onClick={() => setSessionMode('practice')}
+              className="px-6 py-3 bg-primary text-white rounded-full font-medium"
             >
-              Learn More Birds
+              Practice Anyway
             </button>
-          )}
+          ) : null}
         </>
       )}
     </div>

--- a/beakspeak/src/core/lesson.test.ts
+++ b/beakspeak/src/core/lesson.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { getNextLesson, isLessonAvailable, isLessonComplete, buildIntroQuiz, buildReviewQuiz } from './lesson'
+import {
+  getLessonLockReason,
+  getNextLesson,
+  isLessonAvailable,
+  isLessonComplete,
+  buildIntroQuiz,
+  buildReviewQuiz,
+} from './lesson'
 import type { Lesson, Species, UserProgress } from './types'
 
 function makeLesson(num: number, speciesIds: string[]): Lesson {
@@ -51,6 +58,30 @@ const lessons = [
 ]
 
 describe('isLessonAvailable', () => {
+  it('returns a prerequisite lock reason when the previous lesson is incomplete', () => {
+    expect(getLessonLockReason(2, [], new Map())).toEqual({ type: 'prerequisite' })
+  })
+
+  it('returns a relearning lock reason when any bird is relearning', () => {
+    const progress = new Map([
+      ['x', makeProgress('x', { state: 'relearning', introduced: true })],
+    ])
+
+    expect(getLessonLockReason(2, [1], progress)).toEqual({ type: 'relearning' })
+  })
+
+  it('gives relearning precedence when prerequisite and relearning locks both apply', () => {
+    const progress = new Map([
+      ['x', makeProgress('x', { state: 'relearning', introduced: true })],
+    ])
+
+    expect(getLessonLockReason(3, [1], progress)).toEqual({ type: 'relearning' })
+  })
+
+  it('returns no lock reason for lesson 1 when nothing is relearning', () => {
+    expect(getLessonLockReason(1, [], new Map())).toBeNull()
+  })
+
   it('lesson 1 is always available when no birds are relearning', () => {
     expect(isLessonAvailable(1, [], new Map())).toBe(true)
   })
@@ -65,6 +96,11 @@ describe('isLessonAvailable', () => {
       ['x', makeProgress('x', { state: 'relearning', introduced: true })],
     ])
     expect(isLessonAvailable(2, [1], progress)).toBe(false)
+  })
+
+  it('delegates availability to the structured lock reason helper', () => {
+    expect(isLessonAvailable(3, [1, 2], new Map())).toBe(true)
+    expect(isLessonAvailable(3, [1], new Map())).toBe(false)
   })
 })
 

--- a/beakspeak/src/core/lesson.ts
+++ b/beakspeak/src/core/lesson.ts
@@ -1,18 +1,33 @@
 import type { Lesson, Species, UserProgress, IntroQuizItem } from './types'
 
+export interface LessonLockReason {
+  type: 'prerequisite' | 'relearning'
+}
+
+export function getLessonLockReason(
+  lessonNum: number,
+  completedLessonNums: number[],
+  allProgress: Map<string, UserProgress>,
+): LessonLockReason | null {
+  for (const progress of allProgress.values()) {
+    if (progress.state === 'relearning') return { type: 'relearning' }
+  }
+
+  if (lessonNum === 1) return null
+
+  if (!completedLessonNums.includes(lessonNum - 1)) {
+    return { type: 'prerequisite' }
+  }
+
+  return null
+}
+
 export function isLessonAvailable(
   lessonNum: number,
   completedLessonNums: number[],
   allProgress: Map<string, UserProgress>,
 ): boolean {
-  // Block if any bird is in relearning state
-  for (const progress of allProgress.values()) {
-    if (progress.state === 'relearning') return false
-  }
-  // Lesson 1 is always available
-  if (lessonNum === 1) return true
-  // Otherwise, previous lesson must be complete
-  return completedLessonNums.includes(lessonNum - 1)
+  return getLessonLockReason(lessonNum, completedLessonNums, allProgress) === null
 }
 
 export function isLessonComplete(

--- a/rpi/implementation/unlockable-guided-path-implementation-2026-04-22-1638.md
+++ b/rpi/implementation/unlockable-guided-path-implementation-2026-04-22-1638.md
@@ -70,7 +70,7 @@ This slice includes the structured lesson-lock reason from the PRD's "Unlock Fut
 
 #### 1.1. Add structured lesson lock reasons in `core/lesson.ts`
 
-- [ ] Task complete
+- [x] Task complete
 
 **Type**: WRITE  
 **Output**: `beakspeak/src/core/lesson.ts` exposes a structured lock-reason helper and `isLessonAvailable()` delegates to it.  
@@ -80,7 +80,7 @@ Update [lesson.ts](/Users/mistercheese/Code/avilingo-v2/beakspeak/src/core/lesso
 
 #### 1.2. Cover the lock-reason helper with unit tests
 
-- [ ] Task complete
+- [x] Task complete
 
 **Type**: TEST  
 **Output**: `beakspeak/src/core/lesson.test.ts` covers prerequisite, relearning, and precedence behavior.  
@@ -90,7 +90,7 @@ Extend [lesson.test.ts](/Users/mistercheese/Code/avilingo-v2/beakspeak/src/core/
 
 #### 1.3. Create the unlock dialog and consequence copy helper
 
-- [ ] Task complete
+- [x] Task complete
 
 **Type**: WRITE  
 **Output**: `UnlockDialog` and a local learn-layer copy helper exist and render reason-specific explanatory copy without mutating progress.  
@@ -100,7 +100,7 @@ Create a new learn UI modal component and its small local consequence-copy helpe
 
 #### 1.4. Wire locked lessons in `LearnTab` to open and dismiss the dialog
 
-- [ ] Task complete
+- [x] Task complete
 
 **Type**: WRITE  
 **Output**: Tapping a locked lesson in Learn opens `UnlockDialog` and dismissing it leaves progress unchanged.  
@@ -110,7 +110,7 @@ Update [LearnTab.tsx](/Users/mistercheese/Code/avilingo-v2/beakspeak/src/compone
 
 #### 1.5. Add component tests for locked-lesson dialog behavior
 
-- [ ] Task complete
+- [x] Task complete
 
 **Type**: TEST  
 **Output**: A learn component test file verifies locked lessons open the modal with reason-specific copy and dismiss cleanly.  
@@ -165,7 +165,7 @@ This slice covers the end-to-end behavior described in the PRD's "Unlock Future 
 
 #### 2.1. Add skip-ahead confirmation state changes in `LearnTab`
 
-- [ ] Task complete
+- [x] Task complete
 
 **Type**: WRITE  
 **Output**: Confirming the unlock dialog immediately introduces skipped intervening lessons while preserving existing progress records.  
@@ -175,7 +175,7 @@ Update [LearnTab.tsx](/Users/mistercheese/Code/avilingo-v2/beakspeak/src/compone
 
 #### 2.2. Convert `LearnSession` to explicit launch modes and implement `unlock`
 
-- [ ] Task complete
+- [x] Task complete
 
 **Type**: WRITE  
 **Output**: `LearnSession` accepts an explicit `mode` prop and `unlock` mode skips warm-up while otherwise completing like a normal lesson.  
@@ -185,7 +185,7 @@ Refactor [LearnSession.tsx](/Users/mistercheese/Code/avilingo-v2/beakspeak/src/c
 
 #### 2.3. Launch confirmed unlocks into `LearnSession` with one-launch-only semantics
 
-- [ ] Task complete
+- [x] Task complete
 
 **Type**: WRITE  
 **Output**: `LearnTab` launches confirmed skip-ahead lessons in `unlock` mode and requires confirmation again after exiting.  
@@ -195,7 +195,7 @@ Finish the `LearnTab` integration by replacing the current single `activeLesson`
 
 #### 2.4. Add tests for skip-ahead auto-completion and unlock mode
 
-- [ ] Task complete
+- [x] Task complete
 
 **Type**: TEST  
 **Output**: Learn tests cover skipped-lesson introduction rules and unlock-mode session behavior.  
@@ -250,7 +250,7 @@ This slice covers the PRD's "Redo a Completed Lesson" feature across `LearnTab`,
 
 #### 3.1. Let completed lessons launch in `redo` mode from `LearnTab`
 
-- [ ] Task complete
+- [x] Task complete
 
 **Type**: WRITE  
 **Output**: Completed lessons remain visually complete but are clickable and launch redo mode even during relearning.  
@@ -260,7 +260,7 @@ Update [LearnTab.tsx](/Users/mistercheese/Code/avilingo-v2/beakspeak/src/compone
 
 #### 3.2. Add `redo` behavior to `LearnSession`
 
-- [ ] Task complete
+- [x] Task complete
 
 **Type**: WRITE  
 **Output**: `LearnSession` supports `redo` mode with schedule-neutral completion copy and no `introduceSpecies()` call.  
@@ -270,7 +270,7 @@ Extend [LearnSession.tsx](/Users/mistercheese/Code/avilingo-v2/beakspeak/src/com
 
 #### 3.3. Add lesson-quiz back navigation support to `IntroQuiz`
 
-- [ ] Task complete
+- [x] Task complete
 
 **Type**: WRITE  
 **Output**: `IntroQuiz` supports an optional `onBack` control that exits lesson study flows.  
@@ -280,7 +280,7 @@ Update [IntroQuiz.tsx](/Users/mistercheese/Code/avilingo-v2/beakspeak/src/compon
 
 #### 3.4. Add component tests for redo and lesson-quiz back behavior
 
-- [ ] Task complete
+- [x] Task complete
 
 **Type**: TEST  
 **Output**: Learn tests cover completed-lesson redo launches, schedule-neutral completion, and `IntroQuiz` back behavior.  
@@ -336,7 +336,7 @@ This slice covers the PRD's "Practice When Nothing Is Due" feature across `QuizT
 
 #### 4.1. Add practice availability branching in `QuizTab`
 
-- [ ] Task complete
+- [x] Task complete
 
 **Type**: WRITE  
 **Output**: `QuizTab` shows the correct CTA mix for review, learn, relearning, practice, and all-lessons-complete states.  
@@ -346,7 +346,7 @@ Update [QuizTab.tsx](/Users/mistercheese/Code/avilingo-v2/beakspeak/src/componen
 
 #### 4.2. Add `practice` mode to `QuizSession`
 
-- [ ] Task complete
+- [x] Task complete
 
 **Type**: WRITE  
 **Output**: `QuizSession` accepts `review` or `practice` mode and suppresses persistent side effects in practice mode.  
@@ -356,7 +356,7 @@ Refactor [QuizSession.tsx](/Users/mistercheese/Code/avilingo-v2/beakspeak/src/co
 
 #### 4.3. Make `QuizResult` mode-aware
 
-- [ ] Task complete
+- [x] Task complete
 
 **Type**: WRITE  
 **Output**: `QuizResult` renders practice-specific schedule-neutral copy while preserving the existing incorrect-answer list.  
@@ -366,7 +366,7 @@ Update [QuizResult.tsx](/Users/mistercheese/Code/avilingo-v2/beakspeak/src/compo
 
 #### 4.4. Add component tests for practice gating and inert session behavior
 
-- [ ] Task complete
+- [x] Task complete
 
 **Type**: TEST  
 **Output**: Quiz component tests cover empty-state branching, practice-mode labeling, and absence of persistent writes.  


### PR DESCRIPTION
## What changed
- add guided-path unlock handling in Learn so locked lessons can explain why they are blocked and optionally be opened anyway
- add unlock-mode and redo-mode session behavior, including updated completion copy and quiz tab messaging
- add unit coverage for learn/quiz unlock and practice paths, including the Framer Motion test mock fix that removed React unknown-prop warnings
- update the implementation note for the unlockable guided path work

## Why
- the app needed a controlled way to let users skip ahead or revisit completed lessons without breaking the guided path UX
- the test suite was also emitting React stderr from motion props being forwarded by a test mock

## Impact
- users can now choose to open locked lessons with explicit consequences instead of hitting a dead end
- completed lessons can be revisited more clearly, and quiz entry points better reflect review, practice, and relearning states
- unit tests are quieter and cover more of the learn and quiz state transitions

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`
- `npm run test:e2e`
- manual browser QA of the locked-lesson unlock flow with `agent-browser`