### PR TITLE
Add nondestructive admin audio trims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ admin/               ← Local-only audio curation tool (not deployed)
 site/                ← Landing page for unformedideas.com
 scripts/             ← Build/deploy scripts
 download_media.py    ← Content pipeline: downloads audio + photos, builds manifest
+export_app_audio.py  ← App-audio export: regenerates manual trim outputs + manifest from existing local app audio
 populate_content.py  ← Content pipeline: queries Xeno-canto + Wikipedia, ranks mixed candidates
 tier1_seattle_birds_populated.json  ← Candidate pool with per-clip role assignments (checked in)
 wrangler.toml        ← Cloudflare Workers config
@@ -152,6 +153,7 @@ Two Python scripts fetch and process media from external APIs. Not part of the a
 
 - `populate_content.py` — queries Xeno-canto API and Wikipedia; builds unified `audio_clips.candidates` (`schema_version: 2`) with `candidate_id`, `source_role`, and `selected_role` (`none`/`song`/`call`); stores rich metadata plus persisted `analysis` and `segment` fields; preserves manual role assignments from prior runs
 - `download_media.py` — downloads all candidates, normalizes with ffmpeg (loudnorm, persisted-segment trim, OGG Opus 96kbps), outputs to `beakspeak/public/content/`; manifest roles are resolved from `selected_role` with `--export-mode all|commercial`
+- `export_app_audio.py` — reads existing local app audio from `beakspeak/public/content/audio/{species}/{xc_id}.ogg`, writes manual trim outputs to `beakspeak/public/content/audio/{species}/trimmed/{xc_id}.ogg`, and regenerates the manifest with trim-aware URLs. Use `--force-audio` after changing an existing trim. It does not download Xeno-canto source audio; rerun `download_media.py` if local source app audio is missing.
 - Managed with `uv` (see `pyproject.toml`): https://docs.astral.sh/uv
 - Requires: Python 3.12+, ffmpeg, `requests`, `Pillow`
 - `XC_API_KEY` env var required for `populate_content.py`
@@ -160,7 +162,7 @@ Two Python scripts fetch and process media from external APIs. Not part of the a
 ### Audio Admin (local only, not deployed)
 
 - `admin/server.py` — Python stdlib HTTP server; run with `python3 admin/server.py` from repo root; serves on `http://localhost:8765`
-- `admin/index.html` — single-file vanilla JS UI; shows mixed ranked candidates with spectrogram/metadata/evidence and a role selector (`none`/`song`/`call`); saves immediately to `tier1_seattle_birds_populated.json`
+- `admin/index.html` — single-file vanilla JS UI; shows mixed ranked candidates with spectrogram/metadata/evidence, a role selector (`none`/`song`/`call`), and manual trim controls for selected clips; saves immediately to `tier1_seattle_birds_populated.json`
 - No extra dependencies beyond Python stdlib
 
 ## Build & Deploy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ Two Python scripts fetch and process media from external APIs. Not part of the a
 
 - `populate_content.py` — queries Xeno-canto API and Wikipedia; builds unified `audio_clips.candidates` (`schema_version: 2`) with `candidate_id`, `source_role`, and `selected_role` (`none`/`song`/`call`); stores rich metadata plus persisted `analysis` and `segment` fields; preserves manual role assignments from prior runs
 - `download_media.py` — downloads all candidates, normalizes with ffmpeg (loudnorm, persisted-segment trim, OGG Opus 96kbps), outputs to `beakspeak/public/content/`; manifest roles are resolved from `selected_role` with `--export-mode all|commercial`
-- `export_app_audio.py` — reads existing local app audio from `beakspeak/public/content/audio/{species}/{xc_id}.ogg`, writes manual trim outputs to `beakspeak/public/content/audio/{species}/trimmed/{xc_id}.ogg`, and regenerates the manifest with trim-aware URLs. Use `--force-audio` after changing an existing trim. It does not download Xeno-canto source audio; rerun `download_media.py` if local source app audio is missing.
+- `export_app_audio.py` — reads existing local app audio from `beakspeak/public/content/audio/{species}/{xc_id}.ogg`, writes manual trim outputs to `beakspeak/public/content/audio/{species}/trimmed/{safe_candidate_id}.ogg`, and regenerates the manifest with trim-aware URLs. Use `--force-audio` after changing an existing trim. It does not download Xeno-canto source audio; rerun `download_media.py` if local source app audio is missing.
 - Managed with `uv` (see `pyproject.toml`): https://docs.astral.sh/uv
 - Requires: Python 3.12+, ffmpeg, `requests`, `Pillow`
 - `XC_API_KEY` env var required for `populate_content.py`

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The app is a single-page app with no backend — all data is served as static fi
 
 ## Audio Admin
 
-A local-only tool for reviewing the mixed candidate pool and assigning final export roles.
+A local-only tool for reviewing the mixed candidate pool, assigning final export roles, and saving non-destructive manual trims for selected clips.
 
 ```bash
 # Run from repo root (no extra dependencies — Python stdlib only)
@@ -69,7 +69,7 @@ python3 admin/server.py
 # → http://localhost:8765
 ```
 
-**What it shows per clip:** spectrogram (pre-rendered), play/pause, quality grade, type (song / call / alarm call / etc.), sex, stage, recording method, location, recordist, score/rank, license, BirdNET/segment evidence, remarks, and a link to the Xeno-canto page.
+**What it shows per clip:** spectrogram (pre-rendered), play/pause, quality grade, type (song / call / alarm call / etc.), sex, stage, recording method, location, recordist, score/rank, license, BirdNET/segment evidence, remarks, and a link to the Xeno-canto page. Clips assigned to `song` or `call` also show start/end trim controls, selected-segment preview, save, and reset.
 
 **Species header:** mnemonic and any Wikipedia audio clips for reference.
 
@@ -77,8 +77,9 @@ python3 admin/server.py
 1. Run `uv run python3 populate_content.py` to fetch/rank candidates and persist unified `audio_clips.candidates`
 2. Run `uv run python3 download_media.py` to download and normalize candidate media for local preview
 3. Open the admin and review mixed ranked candidates; assign each clip to `song`, `call`, or `none`
-4. Assignments save immediately to `tier1_seattle_birds_populated.json` via `/api/assign-role`
-5. Run `uv run python3 download_media.py --export-mode all` (or `--export-mode commercial`) to regenerate `manifest.json`
+4. For assigned clips, optionally save manual trim metadata. Trims are saved to `candidate.segment` and do not overwrite local audio.
+5. Assignments save immediately to `tier1_seattle_birds_populated.json` via `/api/assign-role`; trims save via `/api/segment`
+6. Run `uv run python3 export_app_audio.py --force-audio --export-mode all` (or `--export-mode commercial`) to generate trimmed app audio and regenerate `manifest.json`
 
 ## Re-generating media
 
@@ -92,10 +93,14 @@ python3 admin/server.py
 uv run python3 populate_content.py                   # → tier1_seattle_birds_populated.json
 uv run python3 download_media.py --export-mode all  # → beakspeak/public/content/ + manifest.json
 
-# Manifest/media rebuild after admin role assignment
-uv run python3 download_media.py --export-mode all
-uv run python3 download_media.py --export-mode commercial
+# Manifest/media rebuild after admin role assignment and optional manual trims
+uv run python3 export_app_audio.py --force-audio --export-mode all
+uv run python3 export_app_audio.py --force-audio --export-mode commercial
 ```
+
+Manual trim metadata is non-destructive. The existing source app audio stays at `beakspeak/public/content/audio/{species}/{xc_id}.ogg`; generated trimmed app audio is written to `beakspeak/public/content/audio/{species}/trimmed/{xc_id}.ogg`. If a trimmed output already exists, `export_app_audio.py` warns and skips regeneration unless `--force-audio` is provided. If source app audio is missing, rerun `uv run python3 download_media.py --export-mode all` to restore it before exporting trims.
+
+`export_app_audio.py` does not download original Xeno-canto audio and does not rerun BirdNET analysis. Use `populate_content.py` and `download_media.py` for full source refreshes.
 
 Audio and photos are gitignored; `manifest.json` and `tier1_seattle_birds_populated.json` are checked in.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ uv run python3 export_app_audio.py --force-audio --export-mode all
 uv run python3 export_app_audio.py --force-audio --export-mode commercial
 ```
 
-Manual trim metadata is non-destructive. The existing source app audio stays at `beakspeak/public/content/audio/{species}/{xc_id}.ogg`; generated trimmed app audio is written to `beakspeak/public/content/audio/{species}/trimmed/{xc_id}.ogg`. If a trimmed output already exists, `export_app_audio.py` warns and skips regeneration unless `--force-audio` is provided. If source app audio is missing, rerun `uv run python3 download_media.py --export-mode all` to restore it before exporting trims.
+Manual trim metadata is non-destructive. The existing source app audio stays at `beakspeak/public/content/audio/{species}/{xc_id}.ogg`; generated trimmed app audio is written to `beakspeak/public/content/audio/{species}/trimmed/{safe_candidate_id}.ogg`. If a trimmed output already exists, `export_app_audio.py` warns and skips regeneration unless `--force-audio` is provided. If source app audio is missing, rerun `uv run python3 download_media.py --export-mode all` to restore it before exporting trims.
 
 `export_app_audio.py` does not download original Xeno-canto audio and does not rerun BirdNET analysis. Use `populate_content.py` and `download_media.py` for full source refreshes.
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -1266,7 +1266,7 @@ async function saveSegment(speciesId, candidateId, xcId, startS, endS, card) {
     ) : null;
     if (candidate) applyCandidateSegment(candidate, body.segment);
     setStatus(`XC${xcId} trim saved`);
-    if (candidate) renderSpeciesView(sp);
+    if (candidate && activeSpeciesId === speciesId) renderSpeciesView(sp);
   } catch (e) {
     setStatus('Error saving trim: ' + e.message);
     card.querySelector('.trim-warning').textContent = e.message;
@@ -1290,7 +1290,7 @@ async function resetSegment(speciesId, candidateId, xcId, card) {
     ) : null;
     if (candidate) resetCandidateSegment(candidate);
     setStatus(`XC${xcId} trim reset`);
-    if (sp) renderSpeciesView(sp);
+    if (sp && activeSpeciesId === speciesId) renderSpeciesView(sp);
   } catch (e) {
     setStatus('Error resetting trim: ' + e.message);
     card.querySelector('.trim-warning').textContent = e.message;

--- a/admin/index.html
+++ b/admin/index.html
@@ -316,7 +316,16 @@
   .clip-length {
     font-size: 10px;
     color: var(--text-dim);
-    text-align: right;
+  }
+  .clip-time-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    font-variant-numeric: tabular-nums;
+  }
+  .clip-current-time {
+    color: var(--accent);
+    font-size: 10px;
   }
 
   /* Role selector */
@@ -566,6 +575,7 @@
 <script type="module">
 import {
   applyCandidateSegment,
+  formatPlaybackTime,
   getSegmentDurationWarning,
   normalizeSegment,
   resetCandidateSegment,
@@ -844,7 +854,10 @@ function buildClipCard(sp, clip) {
         <div class="progress-bar-wrap">
           <div class="progress-bar-fill" data-xcid="${xcId}"></div>
         </div>
-        <div class="clip-length">${clip.length || ''}</div>
+        <div class="clip-time-row">
+          <span class="clip-current-time" data-xcid="${xcId}">0:00.0</span>
+          <span class="clip-length">${clip.length || ''}</span>
+        </div>
       </div>
       <div class="role-wrap">
         <label class="role-label" for="role-${candidateId}">Role</label>
@@ -943,12 +956,15 @@ function playClip(xcId, audioSrc, card) {
 
   const btn = card.querySelector(`.play-btn[data-xcid="${xcId}"]`);
   const fill = card.querySelector(`.progress-bar-fill[data-xcid="${xcId}"]`);
+  const timeEl = card.querySelector(`.clip-current-time[data-xcid="${xcId}"]`);
 
   btn.textContent = '⏸';
   btn.classList.add('active');
   card.classList.add('playing');
+  if (timeEl) timeEl.textContent = formatPlaybackTime(0);
 
   audio.addEventListener('timeupdate', () => {
+    if (timeEl) timeEl.textContent = formatPlaybackTime(audio.currentTime);
     if (audio.duration) {
       const pct = (audio.currentTime / audio.duration) * 100;
       fill.style.width = pct + '%';
@@ -984,11 +1000,14 @@ function playSelectedSegment(xcId, audioSrc, card, startValue, endValue) {
 
   const btn = card.querySelector(`.play-btn[data-xcid="${xcId}"]`);
   const fill = card.querySelector(`.progress-bar-fill[data-xcid="${xcId}"]`);
+  const timeEl = card.querySelector(`.clip-current-time[data-xcid="${xcId}"]`);
   btn.textContent = '⏸';
   btn.classList.add('active');
   card.classList.add('playing');
+  if (timeEl) timeEl.textContent = formatPlaybackTime(start);
 
   audio.addEventListener('timeupdate', () => {
+    if (timeEl) timeEl.textContent = formatPlaybackTime(audio.currentTime);
     if (audio.currentTime >= end) {
       stopClip(xcId, card);
       return;
@@ -1013,8 +1032,10 @@ function stopClip(xcId, cardEl) {
   if (!card) return;
   const btn = card.querySelector(`.play-btn[data-xcid="${xcId}"]`);
   const fill = card.querySelector(`.progress-bar-fill[data-xcid="${xcId}"]`);
+  const timeEl = card.querySelector(`.clip-current-time[data-xcid="${xcId}"]`);
   if (btn) { btn.textContent = '▶'; btn.classList.remove('active'); }
   if (fill) fill.style.width = '0%';
+  if (timeEl) timeEl.textContent = formatPlaybackTime(0);
   card.classList.remove('playing');
 }
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -495,6 +495,52 @@
   }
   .remarks-row span { color: var(--text); }
 
+  .trim-panel {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: end;
+    gap: 8px;
+    background: rgba(10, 12, 18, 0.42);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 8px 10px;
+  }
+  .trim-field {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+  .trim-field label {
+    color: var(--text-dim);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  .trim-field input {
+    width: 92px;
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    color: var(--text);
+    padding: 5px 7px;
+  }
+  .trim-btn {
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    color: var(--text);
+    cursor: pointer;
+    padding: 6px 9px;
+  }
+  .trim-btn:hover { border-color: var(--accent); }
+  .trim-warning {
+    color: var(--yellow);
+    font-size: 11px;
+    min-height: 14px;
+    flex-basis: 100%;
+  }
+
   /* Scrollbar */
   ::-webkit-scrollbar { width: 6px; }
   ::-webkit-scrollbar-track { background: transparent; }
@@ -518,6 +564,12 @@
 </div>
 
 <script type="module">
+import {
+  applyCandidateSegment,
+  getSegmentDurationWarning,
+  normalizeSegment,
+  resetCandidateSegment,
+} from './trim-state.mjs'
 import {
   applyCandidateRole,
   getGlobalRoleCounts,
@@ -717,6 +769,23 @@ function buildClipCard(sp, clip) {
   const audioSrc = `/audio/${sp.id}/${xcId}.ogg`;
   const selectedRole = clip.selected_role || 'none';
   const isSelected = selectedRole !== 'none';
+  const segment = normalizeSegment(clip.segment);
+  const trimControlsHtml = isSelected ? `
+    <div class="trim-panel" data-candidate-id="${candidateId}" data-xcid="${xcId}">
+      <div class="trim-field">
+        <label for="trim-start-${candidateId}">Start s</label>
+        <input id="trim-start-${candidateId}" class="trim-start" type="number" min="0" step="0.001" value="${escAttr(segment.start_s)}">
+      </div>
+      <div class="trim-field">
+        <label for="trim-end-${candidateId}">End s</label>
+        <input id="trim-end-${candidateId}" class="trim-end" type="number" min="0" step="0.001" value="${escAttr(segment.end_s)}">
+      </div>
+      <button class="trim-btn trim-play" type="button">Play selected segment</button>
+      <button class="trim-btn trim-save" type="button">Save trim</button>
+      <button class="trim-btn trim-reset" type="button">Reset</button>
+      <div class="trim-warning">${escHtml(getSegmentDurationWarning(segment.start_s, segment.end_s))}</div>
+    </div>
+  ` : '';
 
   const card = document.createElement('div');
   card.className = 'clip-card' + (isSelected ? ' selected-card' : '');
@@ -795,6 +864,8 @@ function buildClipCard(sp, clip) {
 
     ${renderClipEvidenceHtml(clip)}
 
+    ${trimControlsHtml}
+
     ${remarksHtml}
 
     <div class="clip-links">
@@ -815,6 +886,27 @@ function buildClipCard(sp, clip) {
   card.querySelector('.role-select').addEventListener('change', async (e) => {
     await assignSelectedRole(sp.id, candidateId, xcId, e.target.value, card);
   });
+
+  const trimPanel = card.querySelector('.trim-panel');
+  if (trimPanel) {
+    const startInput = trimPanel.querySelector('.trim-start');
+    const endInput = trimPanel.querySelector('.trim-end');
+    const warning = trimPanel.querySelector('.trim-warning');
+    const updateWarning = () => {
+      warning.textContent = getSegmentDurationWarning(startInput.value, endInput.value);
+    };
+    startInput.addEventListener('input', updateWarning);
+    endInput.addEventListener('input', updateWarning);
+    trimPanel.querySelector('.trim-save').addEventListener('click', () => {
+      saveSegment(sp.id, candidateId, xcId, startInput.value, endInput.value, card);
+    });
+    trimPanel.querySelector('.trim-reset').addEventListener('click', () => {
+      resetSegment(sp.id, candidateId, xcId, card);
+    });
+    trimPanel.querySelector('.trim-play').addEventListener('click', () => {
+      playSelectedSegment(xcId, audioSrc, card, startInput.value, endInput.value);
+    });
+  }
 
   // Pre-render spectrogram without requiring play
   renderSpectrogram(xcId, audioSrc, card);
@@ -869,6 +961,45 @@ function playClip(xcId, audioSrc, card) {
 
   audio.play().catch(e => console.error('Audio play error:', e));
 
+}
+
+function playSelectedSegment(xcId, audioSrc, card, startValue, endValue) {
+  const start = Number(startValue);
+  const end = Number(endValue);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || start >= end) {
+    setStatus('Enter a valid start/end trim before previewing.');
+    return;
+  }
+
+  for (const [id, s] of Object.entries(audioState)) {
+    if (s.playing) stopClip(id);
+  }
+  for (const [id, s] of Object.entries(wikiAudioState)) {
+    if (s.playing) stopWikiClip(id);
+  }
+
+  const audio = new Audio(audioSrc);
+  audio.currentTime = start;
+  audioState[xcId] = { audio, playing: true, segmentEnd: end };
+
+  const btn = card.querySelector(`.play-btn[data-xcid="${xcId}"]`);
+  const fill = card.querySelector(`.progress-bar-fill[data-xcid="${xcId}"]`);
+  btn.textContent = '⏸';
+  btn.classList.add('active');
+  card.classList.add('playing');
+
+  audio.addEventListener('timeupdate', () => {
+    if (audio.currentTime >= end) {
+      stopClip(xcId, card);
+      return;
+    }
+    if (audio.duration) {
+      const pct = (audio.currentTime / audio.duration) * 100;
+      fill.style.width = pct + '%';
+    }
+  });
+  audio.addEventListener('ended', () => stopClip(xcId, card));
+  audio.play().catch(e => console.error('Audio play error:', e));
 }
 
 function stopClip(xcId, cardEl) {
@@ -1084,6 +1215,7 @@ async function assignSelectedRole(speciesId, candidateId, xcId, selectedRole, ca
     }
 
     setCardAssignedRole(card, selectedRole)
+    if (sp && activeSpeciesId === speciesId) renderSpeciesView(sp)
     const counts = sp ? getSpeciesRoleCounts(sp) : null
     updateSidebarBadge(speciesId, counts)
     updateGlobalCount();
@@ -1092,6 +1224,55 @@ async function assignSelectedRole(speciesId, candidateId, xcId, selectedRole, ca
   } catch (e) {
     setStatus('Error saving: ' + e.message);
     select.value = previousRole
+  }
+}
+
+async function saveSegment(speciesId, candidateId, xcId, startS, endS, card) {
+  try {
+    const res = await fetch('/api/segment', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ species_id: speciesId, candidate_id: candidateId, xc_id: xcId, start_s: startS, end_s: endS }),
+    });
+    if (!res.ok) {
+      const errorBody = await res.json().catch(() => ({ error: 'Server error' }))
+      throw new Error(errorBody.error || 'Server error')
+    }
+    const body = await res.json();
+    const sp = state.species.find(s => s.id === speciesId);
+    const candidate = sp ? getOrderedSpeciesCandidates(sp).find(
+      item => String(item.candidate_id || '') === candidateId || (!candidateId && String(item.xc_id || '') === xcId),
+    ) : null;
+    if (candidate) applyCandidateSegment(candidate, body.segment);
+    setStatus(`XC${xcId} trim saved`);
+    if (candidate) renderSpeciesView(sp);
+  } catch (e) {
+    setStatus('Error saving trim: ' + e.message);
+    card.querySelector('.trim-warning').textContent = e.message;
+  }
+}
+
+async function resetSegment(speciesId, candidateId, xcId, card) {
+  try {
+    const res = await fetch('/api/reset-segment', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ species_id: speciesId, candidate_id: candidateId, xc_id: xcId }),
+    });
+    if (!res.ok) {
+      const errorBody = await res.json().catch(() => ({ error: 'Server error' }))
+      throw new Error(errorBody.error || 'Server error')
+    }
+    const sp = state.species.find(s => s.id === speciesId);
+    const candidate = sp ? getOrderedSpeciesCandidates(sp).find(
+      item => String(item.candidate_id || '') === candidateId || (!candidateId && String(item.xc_id || '') === xcId),
+    ) : null;
+    if (candidate) resetCandidateSegment(candidate);
+    setStatus(`XC${xcId} trim reset`);
+    if (sp) renderSpeciesView(sp);
+  } catch (e) {
+    setStatus('Error resetting trim: ' + e.message);
+    card.querySelector('.trim-warning').textContent = e.message;
   }
 }
 
@@ -1107,7 +1288,11 @@ function shortLicense(url) {
 }
 
 function escHtml(str) {
-  return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+function escAttr(str) {
+  return escHtml(String(str)).replace(/"/g, '&quot;');
 }
 
 // ────────────────────────────────────────────────

--- a/admin/server.py
+++ b/admin/server.py
@@ -16,7 +16,7 @@ REPO_ROOT = Path(__file__).parent.parent
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from populate_content import load_pool_file, save_pool_file
+from populate_content import load_pool_file, normalize_segment_payload, save_pool_file
 
 POOL_FILE = REPO_ROOT / "tier1_seattle_birds_populated.json"
 AUDIO_DIR = REPO_ROOT / "beakspeak/public/content/audio"
@@ -24,6 +24,43 @@ PHOTO_DIR = REPO_ROOT / "beakspeak/public/content/photos"
 ADMIN_DIR = Path(__file__).parent
 PORT = 8765
 VALID_SELECTED_ROLES = {"none", "song", "call"}
+
+
+def _find_candidate(data: dict, species_id: str, candidate_id: str, xc_id: str) -> dict | None:
+    for sp in data.get("species", []):
+        if sp["id"] != species_id:
+            continue
+        for candidate in sp.get("audio_clips", {}).get("candidates", []):
+            matches_candidate_id = candidate_id and str(candidate.get("candidate_id", "")) == candidate_id
+            matches_legacy_xc_id = not candidate_id and str(candidate.get("xc_id", "")) == xc_id
+            if matches_candidate_id or matches_legacy_xc_id:
+                return candidate
+        break
+    return None
+
+
+def _manual_segment_payload(start_s: object, end_s: object) -> dict:
+    try:
+        start = float(start_s)
+        end = float(end_s)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("start_s and end_s must be numeric") from exc
+
+    if start < 0:
+        raise ValueError("start_s must be greater than or equal to 0")
+    if start >= end:
+        raise ValueError("start_s must be less than end_s")
+
+    start = round(start, 3)
+    end = round(end, 3)
+    return normalize_segment_payload({
+        "status": "manual",
+        "start_s": start,
+        "end_s": end,
+        "duration_s": round(end - start, 3),
+        "confidence": None,
+        "fallback_reason": None,
+    })
 
 
 def persist_candidate_role_assignment(
@@ -40,23 +77,58 @@ def persist_candidate_role_assignment(
 
     data = load_pool_file(pool_file)
 
-    updated_candidate = None
-    for sp in data.get("species", []):
-        if sp["id"] != species_id:
-            continue
-        for candidate in sp.get("audio_clips", {}).get("candidates", []):
-            matches_candidate_id = candidate_id and str(candidate.get("candidate_id", "")) == candidate_id
-            matches_legacy_xc_id = not candidate_id and str(candidate.get("xc_id", "")) == xc_id
-            if matches_candidate_id or matches_legacy_xc_id:
-                candidate["selected_role"] = selected_role
-                updated_candidate = candidate
-                break
-        break
+    updated_candidate = _find_candidate(data, species_id, candidate_id, xc_id)
 
     if updated_candidate is None:
         target = candidate_id or xc_id
         raise LookupError(f"clip {target} not found in species {species_id}")
 
+    updated_candidate["selected_role"] = selected_role
+    save_pool_file(pool_file, data)
+    return updated_candidate
+
+
+def persist_candidate_segment(
+    *,
+    pool_file: str | Path,
+    species_id: str,
+    candidate_id: str,
+    xc_id: str,
+    start_s: object,
+    end_s: object,
+) -> dict:
+    """Persist a manual trim window for a selected candidate."""
+    segment = _manual_segment_payload(start_s, end_s)
+    data = load_pool_file(pool_file)
+    updated_candidate = _find_candidate(data, species_id, candidate_id, xc_id)
+
+    if updated_candidate is None:
+        target = candidate_id or xc_id
+        raise LookupError(f"clip {target} not found in species {species_id}")
+    if updated_candidate.get("selected_role") not in {"song", "call"}:
+        raise ValueError("manual trims can only be saved for selected song or call clips")
+
+    updated_candidate["segment"] = segment
+    save_pool_file(pool_file, data)
+    return updated_candidate
+
+
+def reset_candidate_segment(
+    *,
+    pool_file: str | Path,
+    species_id: str,
+    candidate_id: str,
+    xc_id: str,
+) -> dict:
+    """Clear a candidate's manual trim window."""
+    data = load_pool_file(pool_file)
+    updated_candidate = _find_candidate(data, species_id, candidate_id, xc_id)
+
+    if updated_candidate is None:
+        target = candidate_id or xc_id
+        raise LookupError(f"clip {target} not found in species {species_id}")
+
+    updated_candidate["segment"] = normalize_segment_payload({"status": "not_set"})
     save_pool_file(pool_file, data)
     return updated_candidate
 
@@ -108,6 +180,9 @@ class Handler(BaseHTTPRequestHandler):
 
         elif path == "/clip-evidence.mjs":
             self.send_file(ADMIN_DIR / "clip-evidence.mjs")
+
+        elif path == "/trim-state.mjs":
+            self.send_file(ADMIN_DIR / "trim-state.mjs")
 
         elif path == "/api/pool":
             if not POOL_FILE.exists():
@@ -163,6 +238,59 @@ class Handler(BaseHTTPRequestHandler):
                 return
 
             self.send_json({"ok": True, "selected_role": updated_candidate["selected_role"]})
+
+        elif path == "/api/segment":
+            length = int(self.headers.get("Content-Length", 0))
+            body = json.loads(self.rfile.read(length))
+            species_id = body.get("species_id")
+            candidate_id = str(body.get("candidate_id", ""))
+            xc_id = str(body.get("xc_id", ""))
+
+            if not POOL_FILE.exists():
+                self.send_json({"error": "pool file not found"}, 404)
+                return
+
+            try:
+                updated_candidate = persist_candidate_segment(
+                    pool_file=POOL_FILE,
+                    species_id=species_id,
+                    candidate_id=candidate_id,
+                    xc_id=xc_id,
+                    start_s=body.get("start_s"),
+                    end_s=body.get("end_s"),
+                )
+            except ValueError as exc:
+                self.send_json({"error": str(exc)}, 400)
+                return
+            except LookupError as exc:
+                self.send_json({"error": str(exc)}, 404)
+                return
+
+            self.send_json({"ok": True, "segment": updated_candidate["segment"]})
+
+        elif path == "/api/reset-segment":
+            length = int(self.headers.get("Content-Length", 0))
+            body = json.loads(self.rfile.read(length))
+            species_id = body.get("species_id")
+            candidate_id = str(body.get("candidate_id", ""))
+            xc_id = str(body.get("xc_id", ""))
+
+            if not POOL_FILE.exists():
+                self.send_json({"error": "pool file not found"}, 404)
+                return
+
+            try:
+                updated_candidate = reset_candidate_segment(
+                    pool_file=POOL_FILE,
+                    species_id=species_id,
+                    candidate_id=candidate_id,
+                    xc_id=xc_id,
+                )
+            except LookupError as exc:
+                self.send_json({"error": str(exc)}, 404)
+                return
+
+            self.send_json({"ok": True, "segment": updated_candidate["segment"]})
 
         else:
             self.send_error(404)

--- a/admin/trim-state.mjs
+++ b/admin/trim-state.mjs
@@ -24,6 +24,14 @@ export function getSegmentDurationWarning(startValue, endValue) {
   return ''
 }
 
+export function formatPlaybackTime(seconds) {
+  const value = Number(seconds)
+  if (!Number.isFinite(value) || value < 0) return '0:00.0'
+  const minutes = Math.floor(value / 60)
+  const remainingSeconds = value - minutes * 60
+  return `${minutes}:${remainingSeconds.toFixed(1).padStart(4, '0')}`
+}
+
 export function applyCandidateSegment(candidate, segment) {
   candidate.segment = normalizeSegmentForCandidate(segment)
   return candidate

--- a/admin/trim-state.mjs
+++ b/admin/trim-state.mjs
@@ -1,0 +1,59 @@
+export function normalizeSegment(segment) {
+  const status = segment?.status === 'manual' ? 'manual' : 'not_set'
+  const start = Number(segment?.start_s)
+  const end = Number(segment?.end_s)
+  if (status !== 'manual' || !Number.isFinite(start) || !Number.isFinite(end) || start >= end) {
+    return { status: 'not_set', start_s: '', end_s: '', duration_s: null }
+  }
+  return {
+    status,
+    start_s: String(start),
+    end_s: String(end),
+    duration_s: Number((end - start).toFixed(3)),
+  }
+}
+
+export function getSegmentDurationWarning(startValue, endValue) {
+  const start = Number(startValue)
+  const end = Number(endValue)
+  if (!Number.isFinite(start) || !Number.isFinite(end) || start >= end) return ''
+
+  const duration = end - start
+  if (duration < 1) return 'Segment is shorter than 1 second.'
+  if (duration > 20) return 'Segment is longer than 20 seconds.'
+  return ''
+}
+
+export function applyCandidateSegment(candidate, segment) {
+  candidate.segment = normalizeSegmentForCandidate(segment)
+  return candidate
+}
+
+export function resetCandidateSegment(candidate) {
+  candidate.segment = {
+    status: 'not_set',
+    start_s: null,
+    end_s: null,
+    duration_s: null,
+    confidence: null,
+    fallback_reason: null,
+  }
+  return candidate
+}
+
+function normalizeSegmentForCandidate(segment) {
+  const status = segment?.status === 'manual' ? 'manual' : 'not_set'
+  const start = Number(segment?.start_s)
+  const end = Number(segment?.end_s)
+  if (status !== 'manual' || !Number.isFinite(start) || !Number.isFinite(end) || start >= end) {
+    return resetCandidateSegment({}).segment
+  }
+  return {
+    status: 'manual',
+    start_s: Number(start.toFixed(3)),
+    end_s: Number(end.toFixed(3)),
+    duration_s: Number((end - start).toFixed(3)),
+    confidence: null,
+    fallback_reason: null,
+  }
+}

--- a/admin/trim-state.test.mjs
+++ b/admin/trim-state.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import {
   applyCandidateSegment,
+  formatPlaybackTime,
   getSegmentDurationWarning,
   normalizeSegment,
   resetCandidateSegment,
@@ -29,6 +30,13 @@ test('duration warnings flag unusually short or long segments without blocking v
   assert.equal(getSegmentDurationWarning(1, 1.5), 'Segment is shorter than 1 second.')
   assert.equal(getSegmentDurationWarning(1, 22), 'Segment is longer than 20 seconds.')
   assert.equal(getSegmentDurationWarning(1, 8), '')
+})
+
+test('formatPlaybackTime renders current audio time for clip playback', () => {
+  assert.equal(formatPlaybackTime(0), '0:00.0')
+  assert.equal(formatPlaybackTime(3.42), '0:03.4')
+  assert.equal(formatPlaybackTime(65.98), '1:06.0')
+  assert.equal(formatPlaybackTime(Number.NaN), '0:00.0')
 })
 
 test('applyCandidateSegment and resetCandidateSegment update in-memory candidate state', () => {

--- a/admin/trim-state.test.mjs
+++ b/admin/trim-state.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  applyCandidateSegment,
+  getSegmentDurationWarning,
+  normalizeSegment,
+  resetCandidateSegment,
+} from './trim-state.mjs'
+
+test('normalizeSegment exposes saved manual trim values for selected clip controls', () => {
+  assert.deepEqual(
+    normalizeSegment({
+      status: 'manual',
+      start_s: 1.25,
+      end_s: 6.75,
+      duration_s: 5.5,
+    }),
+    {
+      status: 'manual',
+      start_s: '1.25',
+      end_s: '6.75',
+      duration_s: 5.5,
+    },
+  )
+})
+
+test('duration warnings flag unusually short or long segments without blocking valid structure', () => {
+  assert.equal(getSegmentDurationWarning(1, 1.5), 'Segment is shorter than 1 second.')
+  assert.equal(getSegmentDurationWarning(1, 22), 'Segment is longer than 20 seconds.')
+  assert.equal(getSegmentDurationWarning(1, 8), '')
+})
+
+test('applyCandidateSegment and resetCandidateSegment update in-memory candidate state', () => {
+  const candidate = { selected_role: 'song' }
+
+  applyCandidateSegment(candidate, { status: 'manual', start_s: 2, end_s: 5 })
+  assert.deepEqual(candidate.segment, {
+    status: 'manual',
+    start_s: 2,
+    end_s: 5,
+    duration_s: 3,
+    confidence: null,
+    fallback_reason: null,
+  })
+
+  resetCandidateSegment(candidate)
+  assert.deepEqual(candidate.segment, {
+    status: 'not_set',
+    start_s: null,
+    end_s: null,
+    duration_s: null,
+    confidence: null,
+    fallback_reason: null,
+  })
+})

--- a/beakspeak/public/content/manifest.json
+++ b/beakspeak/public/content/manifest.json
@@ -47,7 +47,7 @@
           {
             "xc_id": "171727",
             "xc_url": "https://xeno-canto.org/171727",
-            "audio_url": "/content/audio/amro/trimmed/171727.ogg",
+            "audio_url": "/content/audio/amro/trimmed/xc-171727-song-146.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -84,7 +84,7 @@
           {
             "xc_id": "385843",
             "xc_url": "https://xeno-canto.org/385843",
-            "audio_url": "/content/audio/amro/trimmed/385843.ogg",
+            "audio_url": "/content/audio/amro/trimmed/xc-385843-call-78.ogg",
             "type": "call",
             "xc_type": "call",
             "xc_types": [
@@ -170,7 +170,7 @@
           {
             "xc_id": "531008",
             "xc_url": "https://xeno-canto.org/531008",
-            "audio_url": "/content/audio/amcr/trimmed/531008.ogg",
+            "audio_url": "/content/audio/amcr/trimmed/xc-531008-call-74.ogg",
             "type": "call",
             "xc_type": "call",
             "xc_types": [
@@ -207,7 +207,7 @@
           {
             "xc_id": "682428",
             "xc_url": "https://xeno-canto.org/682428",
-            "audio_url": "/content/audio/amcr/trimmed/682428.ogg",
+            "audio_url": "/content/audio/amcr/trimmed/xc-682428-call-46.ogg",
             "type": "call",
             "xc_type": "call",
             "xc_types": [
@@ -295,7 +295,7 @@
           {
             "xc_id": "803814",
             "xc_url": "https://xeno-canto.org/803814",
-            "audio_url": "/content/audio/sosp/trimmed/803814.ogg",
+            "audio_url": "/content/audio/sosp/trimmed/xc-803814-song-46.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -332,7 +332,7 @@
           {
             "xc_id": "829233",
             "xc_url": "https://xeno-canto.org/829233",
-            "audio_url": "/content/audio/sosp/trimmed/829233.ogg",
+            "audio_url": "/content/audio/sosp/trimmed/xc-829233-call-19.ogg",
             "type": "call",
             "xc_type": "call",
             "xc_types": [
@@ -412,7 +412,7 @@
           {
             "xc_id": "569535",
             "xc_url": "https://xeno-canto.org/569535",
-            "audio_url": "/content/audio/deju/trimmed/569535.ogg",
+            "audio_url": "/content/audio/deju/trimmed/xc-569535-song-41.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -449,7 +449,7 @@
           {
             "xc_id": "254480",
             "xc_url": "https://xeno-canto.org/254480",
-            "audio_url": "/content/audio/deju/trimmed/254480.ogg",
+            "audio_url": "/content/audio/deju/trimmed/xc-254480-song-67.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -519,7 +519,7 @@
           {
             "xc_id": "866009",
             "xc_url": "https://xeno-canto.org/866009",
-            "audio_url": "/content/audio/bcch/trimmed/866009.ogg",
+            "audio_url": "/content/audio/bcch/trimmed/xc-866009-song-10.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -556,7 +556,7 @@
           {
             "xc_id": "636533",
             "xc_url": "https://xeno-canto.org/636533",
-            "audio_url": "/content/audio/bcch/trimmed/636533.ogg",
+            "audio_url": "/content/audio/bcch/trimmed/xc-636533-song-18.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -642,7 +642,7 @@
           {
             "xc_id": "575461",
             "xc_url": "https://xeno-canto.org/575461",
-            "audio_url": "/content/audio/spto/trimmed/575461.ogg",
+            "audio_url": "/content/audio/spto/trimmed/xc-575461-song-114.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -679,7 +679,7 @@
           {
             "xc_id": "717557",
             "xc_url": "https://xeno-canto.org/717557",
-            "audio_url": "/content/audio/spto/trimmed/717557.ogg",
+            "audio_url": "/content/audio/spto/trimmed/xc-717557-song-51.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -759,7 +759,7 @@
           {
             "xc_id": "875451",
             "xc_url": "https://xeno-canto.org/875451",
-            "audio_url": "/content/audio/hofi/trimmed/875451.ogg",
+            "audio_url": "/content/audio/hofi/trimmed/xc-875451-song-13.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -796,7 +796,7 @@
           {
             "xc_id": "573017",
             "xc_url": "https://xeno-canto.org/573017",
-            "audio_url": "/content/audio/hofi/trimmed/573017.ogg",
+            "audio_url": "/content/audio/hofi/trimmed/xc-573017-call-24.ogg",
             "type": "flight call",
             "xc_type": "flight call",
             "xc_types": [
@@ -875,7 +875,7 @@
           {
             "xc_id": "645833",
             "xc_url": "https://xeno-canto.org/645833",
-            "audio_url": "/content/audio/nofl/trimmed/645833.ogg",
+            "audio_url": "/content/audio/nofl/trimmed/xc-645833-song-7.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -912,7 +912,7 @@
           {
             "xc_id": "613544",
             "xc_url": "https://xeno-canto.org/613544",
-            "audio_url": "/content/audio/nofl/trimmed/613544.ogg",
+            "audio_url": "/content/audio/nofl/trimmed/xc-613544-call-45.ogg",
             "type": "call, contact call",
             "xc_type": "call, contact call",
             "xc_types": [
@@ -999,7 +999,7 @@
           {
             "xc_id": "603262",
             "xc_url": "https://xeno-canto.org/603262",
-            "audio_url": "/content/audio/stja/trimmed/603262.ogg",
+            "audio_url": "/content/audio/stja/trimmed/xc-603262-call-53.ogg",
             "type": "call, imitation, mimicry/imitation",
             "xc_type": "call, imitation, mimicry/imitation",
             "xc_types": [
@@ -1038,7 +1038,7 @@
           {
             "xc_id": "109654",
             "xc_url": "https://xeno-canto.org/109654",
-            "audio_url": "/content/audio/stja/trimmed/109654.ogg",
+            "audio_url": "/content/audio/stja/trimmed/xc-109654-call-121.ogg",
             "type": "call",
             "xc_type": "call",
             "xc_types": [
@@ -1118,7 +1118,7 @@
           {
             "xc_id": "800769",
             "xc_url": "https://xeno-canto.org/800769",
-            "audio_url": "/content/audio/bewr/trimmed/800769.ogg",
+            "audio_url": "/content/audio/bewr/trimmed/xc-800769-song-28.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -1155,7 +1155,7 @@
           {
             "xc_id": "553922",
             "xc_url": "https://xeno-canto.org/553922",
-            "audio_url": "/content/audio/bewr/trimmed/553922.ogg",
+            "audio_url": "/content/audio/bewr/trimmed/xc-553922-song-98.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -1241,7 +1241,7 @@
           {
             "xc_id": "860679",
             "xc_url": "https://xeno-canto.org/860679",
-            "audio_url": "/content/audio/anhu/trimmed/860679.ogg",
+            "audio_url": "/content/audio/anhu/trimmed/xc-860679-song-40.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -1278,7 +1278,7 @@
           {
             "xc_id": "697495",
             "xc_url": "https://xeno-canto.org/697495",
-            "audio_url": "/content/audio/anhu/trimmed/697495.ogg",
+            "audio_url": "/content/audio/anhu/trimmed/xc-697495-call-6.ogg",
             "type": "flight call",
             "xc_type": "flight call",
             "xc_types": [
@@ -1357,7 +1357,7 @@
           {
             "xc_id": "702313",
             "xc_url": "https://xeno-canto.org/702313",
-            "audio_url": "/content/audio/cbch/trimmed/702313.ogg",
+            "audio_url": "/content/audio/cbch/trimmed/xc-702313-call-10.ogg",
             "type": "call, song",
             "xc_type": "call, song",
             "xc_types": [
@@ -1395,7 +1395,7 @@
           {
             "xc_id": "364352",
             "xc_url": "https://xeno-canto.org/364352",
-            "audio_url": "/content/audio/cbch/trimmed/364352.ogg",
+            "audio_url": "/content/audio/cbch/trimmed/xc-364352-call-27.ogg",
             "type": "call",
             "xc_type": "call",
             "xc_types": [
@@ -1465,7 +1465,7 @@
           {
             "xc_id": "215759",
             "xc_url": "https://xeno-canto.org/215759",
-            "audio_url": "/content/audio/bush/trimmed/215759.ogg",
+            "audio_url": "/content/audio/bush/trimmed/xc-215759-song-2.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -1502,7 +1502,7 @@
           {
             "xc_id": "149398",
             "xc_url": "https://xeno-canto.org/149398",
-            "audio_url": "/content/audio/bush/trimmed/149398.ogg",
+            "audio_url": "/content/audio/bush/trimmed/xc-149398-call-45.ogg",
             "type": "call",
             "xc_type": "call",
             "xc_types": [
@@ -1581,7 +1581,7 @@
           {
             "xc_id": "345344",
             "xc_url": "https://xeno-canto.org/345344",
-            "audio_url": "/content/audio/gcsp/trimmed/345344.ogg",
+            "audio_url": "/content/audio/gcsp/trimmed/xc-345344-song-18.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -1618,7 +1618,7 @@
           {
             "xc_id": "440249",
             "xc_url": "https://xeno-canto.org/440249",
-            "audio_url": "/content/audio/gcsp/trimmed/440249.ogg",
+            "audio_url": "/content/audio/gcsp/trimmed/xc-440249-call-4.ogg",
             "type": "call, song",
             "xc_type": "call, song",
             "xc_types": [
@@ -1689,7 +1689,7 @@
           {
             "xc_id": "593357",
             "xc_url": "https://xeno-canto.org/593357",
-            "audio_url": "/content/audio/eust/trimmed/593357.ogg",
+            "audio_url": "/content/audio/eust/trimmed/xc-593357-song-28.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -1726,7 +1726,7 @@
           {
             "xc_id": "614156",
             "xc_url": "https://xeno-canto.org/614156",
-            "audio_url": "/content/audio/eust/trimmed/614156.ogg",
+            "audio_url": "/content/audio/eust/trimmed/xc-614156-call-3.ogg",
             "type": "call, imitation, mimicry/imitation",
             "xc_type": "call, imitation, mimicry/imitation",
             "xc_types": [

--- a/beakspeak/public/content/manifest.json
+++ b/beakspeak/public/content/manifest.json
@@ -47,7 +47,7 @@
           {
             "xc_id": "171727",
             "xc_url": "https://xeno-canto.org/171727",
-            "audio_url": "/content/audio/amro/171727.ogg",
+            "audio_url": "/content/audio/amro/trimmed/171727.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -84,7 +84,7 @@
           {
             "xc_id": "385843",
             "xc_url": "https://xeno-canto.org/385843",
-            "audio_url": "/content/audio/amro/385843.ogg",
+            "audio_url": "/content/audio/amro/trimmed/385843.ogg",
             "type": "call",
             "xc_type": "call",
             "xc_types": [
@@ -119,7 +119,7 @@
         ]
       },
       "photo": {
-        "url": "/content/photos/amro.jpg",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/9/97/American_robin_%2871307%29.jpg",
         "width": 3444,
         "height": 2584,
         "filename": "American_robin_(71307).jpg",
@@ -129,14 +129,14 @@
       },
       "wikipedia_audio": [
         {
-          "url": "/content/audio/amro/wp_0.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/4/4e/American_Robin.ogg",
           "filename": "File:American Robin.ogg",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",
           "commons_page": "https://commons.wikimedia.org/wiki/File%3AAmerican%20Robin.ogg"
         },
         {
-          "url": "/content/audio/amro/wp_1.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/8/8a/Turdus-migratorius-003.ogg",
           "filename": "File:Turdus-migratorius-003.ogg",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",
@@ -170,7 +170,7 @@
           {
             "xc_id": "531008",
             "xc_url": "https://xeno-canto.org/531008",
-            "audio_url": "/content/audio/amcr/531008.ogg",
+            "audio_url": "/content/audio/amcr/trimmed/531008.ogg",
             "type": "call",
             "xc_type": "call",
             "xc_types": [
@@ -207,7 +207,7 @@
           {
             "xc_id": "682428",
             "xc_url": "https://xeno-canto.org/682428",
-            "audio_url": "/content/audio/amcr/682428.ogg",
+            "audio_url": "/content/audio/amcr/trimmed/682428.ogg",
             "type": "call",
             "xc_type": "call",
             "xc_types": [
@@ -242,7 +242,7 @@
         ]
       },
       "photo": {
-        "url": "/content/photos/amcr.jpg",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/0/0a/Corvus-brachyrhynchos-001.jpg",
         "width": 1536,
         "height": 1536,
         "filename": "Corvus-brachyrhynchos-001.jpg",
@@ -252,14 +252,14 @@
       },
       "wikipedia_audio": [
         {
-          "url": "/content/audio/amcr/wp_0.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/4/4c/American_crow_in_spring.ogg",
           "filename": "File:American crow in spring.ogg",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",
           "commons_page": "https://commons.wikimedia.org/wiki/File%3AAmerican%20crow%20in%20spring.ogg"
         },
         {
-          "url": "/content/audio/amcr/wp_1.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Corvus_brachyrhynchos_-_American_Crow_-_XC115429.ogg",
           "filename": "File:Corvus brachyrhynchos - American Crow - XC115429.ogg",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",
@@ -295,7 +295,7 @@
           {
             "xc_id": "803814",
             "xc_url": "https://xeno-canto.org/803814",
-            "audio_url": "/content/audio/sosp/803814.ogg",
+            "audio_url": "/content/audio/sosp/trimmed/803814.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -332,7 +332,7 @@
           {
             "xc_id": "829233",
             "xc_url": "https://xeno-canto.org/829233",
-            "audio_url": "/content/audio/sosp/829233.ogg",
+            "audio_url": "/content/audio/sosp/trimmed/829233.ogg",
             "type": "call",
             "xc_type": "call",
             "xc_types": [
@@ -367,7 +367,7 @@
         ]
       },
       "photo": {
-        "url": "/content/photos/sosp.jpg",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/0/00/Song_sparrow_in_Prospect_Park_%2893031%29.jpg",
         "width": 3257,
         "height": 2284,
         "filename": "Song_sparrow_in_Prospect_Park_(93031).jpg",
@@ -377,7 +377,7 @@
       },
       "wikipedia_audio": [
         {
-          "url": "/content/audio/sosp/wp_0.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/e/e4/Melospiza-melodia-001.ogg",
           "filename": "File:Melospiza-melodia-001.ogg",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",
@@ -412,7 +412,7 @@
           {
             "xc_id": "569535",
             "xc_url": "https://xeno-canto.org/569535",
-            "audio_url": "/content/audio/deju/569535.ogg",
+            "audio_url": "/content/audio/deju/trimmed/569535.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -449,7 +449,7 @@
           {
             "xc_id": "254480",
             "xc_url": "https://xeno-canto.org/254480",
-            "audio_url": "/content/audio/deju/254480.ogg",
+            "audio_url": "/content/audio/deju/trimmed/254480.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -484,7 +484,7 @@
         ]
       },
       "photo": {
-        "url": "/content/photos/deju.jpg",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/5/55/Junco_hyemalis_hyemalis_CT1_%28cropped%29.jpg",
         "width": 2536,
         "height": 1692,
         "filename": "Junco_hyemalis_hyemalis_CT1_(cropped).jpg",
@@ -519,7 +519,7 @@
           {
             "xc_id": "866009",
             "xc_url": "https://xeno-canto.org/866009",
-            "audio_url": "/content/audio/bcch/866009.ogg",
+            "audio_url": "/content/audio/bcch/trimmed/866009.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -556,7 +556,7 @@
           {
             "xc_id": "636533",
             "xc_url": "https://xeno-canto.org/636533",
-            "audio_url": "/content/audio/bcch/636533.ogg",
+            "audio_url": "/content/audio/bcch/trimmed/636533.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -591,7 +591,7 @@
         ]
       },
       "photo": {
-        "url": "/content/photos/bcch.jpg",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/4/4a/Poecile-atricapilla-001.jpg",
         "width": 1024,
         "height": 1024,
         "filename": "Poecile-atricapilla-001.jpg",
@@ -601,14 +601,14 @@
       },
       "wikipedia_audio": [
         {
-          "url": "/content/audio/bcch/wp_0.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/9/9b/Poecile-atricapilla-004.ogg",
           "filename": "File:Poecile-atricapilla-004.ogg",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",
           "commons_page": "https://commons.wikimedia.org/wiki/File%3APoecile-atricapilla-004.ogg"
         },
         {
-          "url": "/content/audio/bcch/wp_1.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/3/3e/Poecile_atricapillus_-_Black-capped_Chickadee_-_XC70185.ogg",
           "filename": "File:Poecile atricapillus - Black-capped Chickadee - XC70185.ogg",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",
@@ -642,7 +642,7 @@
           {
             "xc_id": "575461",
             "xc_url": "https://xeno-canto.org/575461",
-            "audio_url": "/content/audio/spto/575461.ogg",
+            "audio_url": "/content/audio/spto/trimmed/575461.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -679,7 +679,7 @@
           {
             "xc_id": "717557",
             "xc_url": "https://xeno-canto.org/717557",
-            "audio_url": "/content/audio/spto/717557.ogg",
+            "audio_url": "/content/audio/spto/trimmed/717557.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -714,7 +714,7 @@
         ]
       },
       "photo": {
-        "url": "/content/photos/spto.jpg",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/d/d6/Spotted_Towhee_%2832684403303%29.jpg",
         "width": 2273,
         "height": 1818,
         "filename": "Spotted_Towhee_(32684403303).jpg",
@@ -724,7 +724,7 @@
       },
       "wikipedia_audio": [
         {
-          "url": "/content/audio/spto/wp_0.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/e/e3/Pipilo_maculatus_-_Spotted_Towhee_-_XC104528.ogg",
           "filename": "File:Pipilo maculatus - Spotted Towhee - XC104528.ogg",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",
@@ -759,7 +759,7 @@
           {
             "xc_id": "875451",
             "xc_url": "https://xeno-canto.org/875451",
-            "audio_url": "/content/audio/hofi/875451.ogg",
+            "audio_url": "/content/audio/hofi/trimmed/875451.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -796,7 +796,7 @@
           {
             "xc_id": "573017",
             "xc_url": "https://xeno-canto.org/573017",
-            "audio_url": "/content/audio/hofi/573017.ogg",
+            "audio_url": "/content/audio/hofi/trimmed/573017.ogg",
             "type": "flight call",
             "xc_type": "flight call",
             "xc_types": [
@@ -831,7 +831,7 @@
         ]
       },
       "photo": {
-        "url": "/content/photos/hofi.jpg",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/f/f1/House_finch_%2833688%292.jpg",
         "width": 3975,
         "height": 3122,
         "filename": "House_finch_(33688)2.jpg",
@@ -841,7 +841,7 @@
       },
       "wikipedia_audio": [
         {
-          "url": "/content/audio/hofi/wp_0.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/2/23/Carpodacus_mexicanus_vocalizations_-_pone.0027052.s006.oga",
           "filename": "File:Carpodacus mexicanus vocalizations - pone.0027052.s006.oga",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",
@@ -875,7 +875,7 @@
           {
             "xc_id": "645833",
             "xc_url": "https://xeno-canto.org/645833",
-            "audio_url": "/content/audio/nofl/645833.ogg",
+            "audio_url": "/content/audio/nofl/trimmed/645833.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -912,7 +912,7 @@
           {
             "xc_id": "613544",
             "xc_url": "https://xeno-canto.org/613544",
-            "audio_url": "/content/audio/nofl/613544.ogg",
+            "audio_url": "/content/audio/nofl/trimmed/613544.ogg",
             "type": "call, contact call",
             "xc_type": "call, contact call",
             "xc_types": [
@@ -948,7 +948,7 @@
         ]
       },
       "photo": {
-        "url": "/content/photos/nofl.jpg",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/6/60/Northern_yellow-shafted_flicker_male_%2833737%29_%28cropped%29.jpg",
         "width": 2441,
         "height": 2442,
         "filename": "Northern_yellow-shafted_flicker_male_(33737)_(cropped).jpg",
@@ -958,14 +958,14 @@
       },
       "wikipedia_audio": [
         {
-          "url": "/content/audio/nofl/wp_0.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/d/dd/Colaptes_auratus.ogg",
           "filename": "File:Colaptes auratus.ogg",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",
           "commons_page": "https://commons.wikimedia.org/wiki/File%3AColaptes%20auratus.ogg"
         },
         {
-          "url": "/content/audio/nofl/wp_1.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/a/a6/Northern_Flicker_Yosemite_National_Park.ogg",
           "filename": "File:Northern Flicker Yosemite National Park.ogg",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",
@@ -999,7 +999,7 @@
           {
             "xc_id": "603262",
             "xc_url": "https://xeno-canto.org/603262",
-            "audio_url": "/content/audio/stja/603262.ogg",
+            "audio_url": "/content/audio/stja/trimmed/603262.ogg",
             "type": "call, imitation, mimicry/imitation",
             "xc_type": "call, imitation, mimicry/imitation",
             "xc_types": [
@@ -1038,7 +1038,7 @@
           {
             "xc_id": "109654",
             "xc_url": "https://xeno-canto.org/109654",
-            "audio_url": "/content/audio/stja/109654.ogg",
+            "audio_url": "/content/audio/stja/trimmed/109654.ogg",
             "type": "call",
             "xc_type": "call",
             "xc_types": [
@@ -1073,7 +1073,7 @@
         ]
       },
       "photo": {
-        "url": "/content/photos/stja.jpg",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/c/cf/Steller%27s_Jay_flagstaff_arizona.jpg",
         "width": 1226,
         "height": 1854,
         "filename": "Steller's_Jay_flagstaff_arizona.jpg",
@@ -1083,7 +1083,7 @@
       },
       "wikipedia_audio": [
         {
-          "url": "/content/audio/stja/wp_0.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/c/cb/Cyanocitta_stelleri_-_Steller%27s_Jay_-_XC109654.ogg",
           "filename": "File:Cyanocitta stelleri - Steller's Jay - XC109654.ogg",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",
@@ -1118,7 +1118,7 @@
           {
             "xc_id": "800769",
             "xc_url": "https://xeno-canto.org/800769",
-            "audio_url": "/content/audio/bewr/800769.ogg",
+            "audio_url": "/content/audio/bewr/trimmed/800769.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -1155,7 +1155,7 @@
           {
             "xc_id": "553922",
             "xc_url": "https://xeno-canto.org/553922",
-            "audio_url": "/content/audio/bewr/553922.ogg",
+            "audio_url": "/content/audio/bewr/trimmed/553922.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -1190,7 +1190,7 @@
         ]
       },
       "photo": {
-        "url": "/content/photos/bewr.jpg",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/7/71/Bewicks_Wren.jpg",
         "width": 1746,
         "height": 1746,
         "filename": "Bewicks_Wren.jpg",
@@ -1200,14 +1200,14 @@
       },
       "wikipedia_audio": [
         {
-          "url": "/content/audio/bewr/wp_0.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/9/9f/Thryomanes_bewickii_-_Bewick%27s_Wren_-_XC109604.ogg",
           "filename": "File:Thryomanes bewickii - Bewick's Wren - XC109604.ogg",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",
           "commons_page": "https://commons.wikimedia.org/wiki/File%3AThryomanes%20bewickii%20-%20Bewick%27s%20Wren%20-%20XC109604.ogg"
         },
         {
-          "url": "/content/audio/bewr/wp_1.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/f/f2/Thryomanes_bewickii_-_Bewick%27s_Wren_-_XC109632.ogg",
           "filename": "File:Thryomanes bewickii - Bewick's Wren - XC109632.ogg",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",
@@ -1241,7 +1241,7 @@
           {
             "xc_id": "860679",
             "xc_url": "https://xeno-canto.org/860679",
-            "audio_url": "/content/audio/anhu/860679.ogg",
+            "audio_url": "/content/audio/anhu/trimmed/860679.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -1278,7 +1278,7 @@
           {
             "xc_id": "697495",
             "xc_url": "https://xeno-canto.org/697495",
-            "audio_url": "/content/audio/anhu/697495.ogg",
+            "audio_url": "/content/audio/anhu/trimmed/697495.ogg",
             "type": "flight call",
             "xc_type": "flight call",
             "xc_types": [
@@ -1313,7 +1313,7 @@
         ]
       },
       "photo": {
-        "url": "/content/photos/anhu.jpg",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/c/c4/Anna%27s_hummingbird.jpg",
         "width": 2763,
         "height": 1784,
         "filename": "Anna's_hummingbird.jpg",
@@ -1323,7 +1323,7 @@
       },
       "wikipedia_audio": [
         {
-          "url": "/content/audio/anhu/wp_0.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/0/0e/Calypte_anna_-_Anna%27s_Hummingbird_-_XC109651.ogg",
           "filename": "File:Calypte anna - Anna's Hummingbird - XC109651.ogg",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",
@@ -1357,7 +1357,7 @@
           {
             "xc_id": "702313",
             "xc_url": "https://xeno-canto.org/702313",
-            "audio_url": "/content/audio/cbch/702313.ogg",
+            "audio_url": "/content/audio/cbch/trimmed/702313.ogg",
             "type": "call, song",
             "xc_type": "call, song",
             "xc_types": [
@@ -1395,7 +1395,7 @@
           {
             "xc_id": "364352",
             "xc_url": "https://xeno-canto.org/364352",
-            "audio_url": "/content/audio/cbch/364352.ogg",
+            "audio_url": "/content/audio/cbch/trimmed/364352.ogg",
             "type": "call",
             "xc_type": "call",
             "xc_types": [
@@ -1430,7 +1430,7 @@
         ]
       },
       "photo": {
-        "url": "/content/photos/cbch.jpg",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/9/94/Chestnut-backed_Chickadee_2154ab_%28cropped%29.jpg",
         "width": 2447,
         "height": 1855,
         "filename": "Chestnut-backed_Chickadee_2154ab_(cropped).jpg",
@@ -1465,7 +1465,7 @@
           {
             "xc_id": "215759",
             "xc_url": "https://xeno-canto.org/215759",
-            "audio_url": "/content/audio/bush/215759.ogg",
+            "audio_url": "/content/audio/bush/trimmed/215759.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -1502,7 +1502,7 @@
           {
             "xc_id": "149398",
             "xc_url": "https://xeno-canto.org/149398",
-            "audio_url": "/content/audio/bush/149398.ogg",
+            "audio_url": "/content/audio/bush/trimmed/149398.ogg",
             "type": "call",
             "xc_type": "call",
             "xc_types": [
@@ -1537,7 +1537,7 @@
         ]
       },
       "photo": {
-        "url": "/content/photos/bush.jpg",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/d/d7/BushtitMale.jpg",
         "width": 2868,
         "height": 2294,
         "filename": "BushtitMale.jpg",
@@ -1547,7 +1547,7 @@
       },
       "wikipedia_audio": [
         {
-          "url": "/content/audio/bush/wp_0.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/1/1f/Psaltriparus_minimus_%28American_Bushtit%29_vocalizations_-_pone.0027052.s004.oga",
           "filename": "File:Psaltriparus minimus (American Bushtit) vocalizations - pone.0027052.s004.oga",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",
@@ -1581,7 +1581,7 @@
           {
             "xc_id": "345344",
             "xc_url": "https://xeno-canto.org/345344",
-            "audio_url": "/content/audio/gcsp/345344.ogg",
+            "audio_url": "/content/audio/gcsp/trimmed/345344.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -1618,7 +1618,7 @@
           {
             "xc_id": "440249",
             "xc_url": "https://xeno-canto.org/440249",
-            "audio_url": "/content/audio/gcsp/440249.ogg",
+            "audio_url": "/content/audio/gcsp/trimmed/440249.ogg",
             "type": "call, song",
             "xc_type": "call, song",
             "xc_types": [
@@ -1654,7 +1654,7 @@
         ]
       },
       "photo": {
-        "url": "/content/photos/gcsp.jpg",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/5/5e/Zonotrichia_atricapilla_-British_Columbia%2C_Canada-8.jpg",
         "width": 4928,
         "height": 3264,
         "filename": "Zonotrichia_atricapilla_-British_Columbia,_Canada-8.jpg",
@@ -1689,7 +1689,7 @@
           {
             "xc_id": "593357",
             "xc_url": "https://xeno-canto.org/593357",
-            "audio_url": "/content/audio/eust/593357.ogg",
+            "audio_url": "/content/audio/eust/trimmed/593357.ogg",
             "type": "song",
             "xc_type": "song",
             "xc_types": [
@@ -1726,7 +1726,7 @@
           {
             "xc_id": "614156",
             "xc_url": "https://xeno-canto.org/614156",
-            "audio_url": "/content/audio/eust/614156.ogg",
+            "audio_url": "/content/audio/eust/trimmed/614156.ogg",
             "type": "call, imitation, mimicry/imitation",
             "xc_type": "call, imitation, mimicry/imitation",
             "xc_types": [
@@ -1763,7 +1763,7 @@
         ]
       },
       "photo": {
-        "url": "/content/photos/eust.jpg",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/7/7d/Toulouse_-_Sturnus_vulgaris_-_2012-02-26_-_3.jpg",
         "width": 1776,
         "height": 2372,
         "filename": "Toulouse_-_Sturnus_vulgaris_-_2012-02-26_-_3.jpg",
@@ -1773,14 +1773,14 @@
       },
       "wikipedia_audio": [
         {
-          "url": "/content/audio/eust/wp_0.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/e/e5/Common_Starling_%28Sturnus_vulgaris%29_%28W1CDR0001431_BD8%29.ogg",
           "filename": "File:Common Starling (Sturnus vulgaris) (W1CDR0001431 BD8).ogg",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",
           "commons_page": "https://commons.wikimedia.org/wiki/File%3ACommon%20Starling%20%28Sturnus%20vulgaris%29%20%28W1CDR0001431%20BD8%29.ogg"
         },
         {
-          "url": "/content/audio/eust/wp_1.ogg",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/0/07/Sturnus_vulgaris.ogg",
           "filename": "File:Sturnus vulgaris.ogg",
           "source": "wikimedia_commons",
           "license": "CC (see Commons page)",

--- a/export_app_audio.py
+++ b/export_app_audio.py
@@ -7,6 +7,7 @@ beakspeak/public/content/audio and never downloads original Xeno-canto media.
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from copy import deepcopy
@@ -35,8 +36,16 @@ def local_source_path(audio_dir: Path, species_id: str, candidate: dict) -> Path
     return audio_dir / species_id / f"{candidate['xc_id']}.ogg"
 
 
+def trimmed_filename(candidate: dict) -> str:
+    candidate_id = str(candidate.get("candidate_id", "") or "")
+    stem = re.sub(r"[^A-Za-z0-9._-]+", "-", candidate_id).strip(".-")
+    if not stem:
+        stem = str(candidate["xc_id"])
+    return f"{stem}.ogg"
+
+
 def trimmed_output_path(audio_dir: Path, species_id: str, candidate: dict) -> Path:
-    return audio_dir / species_id / "trimmed" / f"{candidate['xc_id']}.ogg"
+    return audio_dir / species_id / "trimmed" / trimmed_filename(candidate)
 
 
 def normal_audio_url(species_id: str, candidate: dict) -> str:
@@ -44,7 +53,7 @@ def normal_audio_url(species_id: str, candidate: dict) -> str:
 
 
 def trimmed_audio_url(species_id: str, candidate: dict) -> str:
-    return f"/content/audio/{species_id}/trimmed/{candidate['xc_id']}.ogg"
+    return f"/content/audio/{species_id}/trimmed/{trimmed_filename(candidate)}"
 
 
 def encode_manual_trim(

--- a/export_app_audio.py
+++ b/export_app_audio.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Export manually trimmed app audio from existing local BeakSpeak audio assets.
+
+This command is intentionally narrow: it reads already-normalized app audio from
+beakspeak/public/content/audio and never downloads original Xeno-canto media.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Callable
+
+from populate_content import build_export_audio_clips, load_pool_file, normalize_audio_clips
+
+INPUT_FILE = Path("tier1_seattle_birds_populated.json")
+AUDIO_DIR = Path("beakspeak/public/content/audio")
+MANIFEST_OUT = Path("beakspeak/public/content/manifest.json")
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+def is_manual_segment(segment: dict | None) -> bool:
+    return (
+        isinstance(segment, dict)
+        and segment.get("status") == "manual"
+        and segment.get("start_s") is not None
+        and segment.get("duration_s") is not None
+    )
+
+
+def local_source_path(audio_dir: Path, species_id: str, candidate: dict) -> Path:
+    return audio_dir / species_id / f"{candidate['xc_id']}.ogg"
+
+
+def trimmed_output_path(audio_dir: Path, species_id: str, candidate: dict) -> Path:
+    return audio_dir / species_id / "trimmed" / f"{candidate['xc_id']}.ogg"
+
+
+def normal_audio_url(species_id: str, candidate: dict) -> str:
+    return f"/content/audio/{species_id}/{candidate['xc_id']}.ogg"
+
+
+def trimmed_audio_url(species_id: str, candidate: dict) -> str:
+    return f"/content/audio/{species_id}/trimmed/{candidate['xc_id']}.ogg"
+
+
+def encode_manual_trim(
+    *,
+    source: Path,
+    output: Path,
+    segment: dict,
+    runner: Runner = subprocess.run,
+) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    tmp_output = output.with_suffix(".tmp.ogg")
+    tmp_output.unlink(missing_ok=True)
+    cmd = [
+        "ffmpeg",
+        "-ss",
+        str(segment["start_s"]),
+        "-t",
+        str(segment["duration_s"]),
+        "-i",
+        str(source),
+        "-af",
+        "loudnorm=I=-16:TP=-1.5:LRA=11",
+        "-c:a",
+        "libopus",
+        "-b:a",
+        "96k",
+        "-y",
+        str(tmp_output),
+    ]
+    result = runner(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        tmp_output.unlink(missing_ok=True)
+        detail = (result.stderr or "").strip()
+        raise RuntimeError(f"ffmpeg failed for {source}: {detail}")
+    tmp_output.replace(output)
+
+
+def prepare_manual_trimmed_audio(
+    *,
+    data: dict,
+    audio_dir: Path,
+    force_audio: bool,
+    runner: Runner = subprocess.run,
+) -> dict:
+    generated: list[Path] = []
+    skipped: list[Path] = []
+    warnings: list[str] = []
+
+    for species in data.get("species", []):
+        species_id = species["id"]
+        audio_clips = normalize_audio_clips(species.get("audio_clips"))
+        species["audio_clips"] = audio_clips
+        for candidate in audio_clips.get("candidates", []):
+            candidate["audio_url"] = normal_audio_url(species_id, candidate)
+            if not is_manual_segment(candidate.get("segment")):
+                continue
+
+            source = local_source_path(audio_dir, species_id, candidate)
+            output = trimmed_output_path(audio_dir, species_id, candidate)
+            candidate["audio_url"] = trimmed_audio_url(species_id, candidate)
+
+            if not source.exists():
+                raise FileNotFoundError(
+                    f"Missing local source app audio for {species_id} XC{candidate['xc_id']}: {source}. "
+                    "Rerun the existing media download/normalization step to redownload the source audio."
+                )
+            if output.exists() and not force_audio:
+                skipped.append(output)
+                warnings.append(
+                    f"Manual trim for {species_id} XC{candidate['xc_id']} skipped because {output} exists; "
+                    "existing trimmed output may be stale. Rerun with --force-audio to regenerate."
+                )
+                continue
+
+            encode_manual_trim(
+                source=source,
+                output=output,
+                segment=candidate["segment"],
+                runner=runner,
+            )
+            generated.append(output)
+
+    return {"generated": generated, "skipped": skipped, "warnings": warnings}
+
+
+def build_trim_aware_manifest(data: dict, export_mode: str) -> tuple[dict, list[str], list[str], list[dict]]:
+    manifest = deepcopy(data)
+    warnings: list[str] = []
+    errors: list[str] = []
+    substitutions: list[dict] = []
+
+    for species in manifest.get("species", []):
+        species.pop("xc_api_query", None)
+        species.pop("wikimedia_search", None)
+        export_report = build_export_audio_clips(
+            species.get("audio_clips"),
+            export_mode=export_mode,
+        )
+        species["audio_clips"] = export_report["audio_clips"]
+        warnings.extend(export_report["warnings"])
+        errors.extend(export_report["errors"])
+        substitutions.extend(export_report["substitutions"])
+
+    return manifest, warnings, errors, substitutions
+
+
+def export_app_audio(
+    *,
+    pool_file: str | Path = INPUT_FILE,
+    audio_dir: str | Path = AUDIO_DIR,
+    manifest_out: str | Path | None = MANIFEST_OUT,
+    export_mode: str = "all",
+    force_audio: bool = False,
+    runner: Runner = subprocess.run,
+) -> dict:
+    data = load_pool_file(pool_file)
+    audio_dir = Path(audio_dir)
+    trim_result = prepare_manual_trimmed_audio(
+        data=data,
+        audio_dir=audio_dir,
+        force_audio=force_audio,
+        runner=runner,
+    )
+    manifest, export_warnings, errors, substitutions = build_trim_aware_manifest(data, export_mode)
+    warnings = [*trim_result["warnings"], *export_warnings]
+
+    if manifest_out is not None:
+        manifest_path = Path(manifest_out)
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(manifest_path, "w") as f:
+            json.dump(manifest, f, indent=2)
+
+    return {
+        "manifest": manifest,
+        "generated": trim_result["generated"],
+        "skipped": trim_result["skipped"],
+        "warnings": warnings,
+        "errors": errors,
+        "substitutions": substitutions,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pool-file", default=str(INPUT_FILE), help="Populated candidate pool JSON file.")
+    parser.add_argument("--audio-dir", default=str(AUDIO_DIR), help="Existing app audio root.")
+    parser.add_argument("--manifest-out", default=str(MANIFEST_OUT), help="Generated app manifest path.")
+    parser.add_argument(
+        "--export-mode",
+        choices=("all", "commercial"),
+        default="all",
+        help="Resolve selected clips for the generated manifest.",
+    )
+    parser.add_argument(
+        "--force-audio",
+        action="store_true",
+        help="Regenerate existing trimmed outputs instead of warning and skipping them.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        result = export_app_audio(
+            pool_file=args.pool_file,
+            audio_dir=args.audio_dir,
+            manifest_out=args.manifest_out,
+            export_mode=args.export_mode,
+            force_audio=args.force_audio,
+        )
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    for path in result["generated"]:
+        print(f"Generated trimmed audio: {path}")
+    for warning in result["warnings"]:
+        print(f"Warning: {warning}", file=sys.stderr)
+    for error in result["errors"]:
+        print(f"Export error: {error}", file=sys.stderr)
+    print(f"Manifest written to {args.manifest_out}")
+    return 1 if result["errors"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rpi/implementation/export-app-audio-trim-implementation-2026-04-24-1359.md
+++ b/rpi/implementation/export-app-audio-trim-implementation-2026-04-24-1359.md
@@ -1,0 +1,259 @@
+# Implementation Issues: Non-Destructive App Audio Trim Export
+
+Parent PRD: `rpi/plans/export-to-app-nondestructive-audio-trim-prd-2026-04-24-1337.md`
+
+Generated: 2026-04-24 13:59 America/Los_Angeles
+
+## Final Scope Decisions
+
+- Current admin previews are sufficient for the first version.
+- Manual trims are trims within `beakspeak/public/content/audio/{species}/{xc_id}.ogg`, not the original Xeno-canto source file.
+- `export_app_audio.py` must read existing local app audio as its source for trimmed exports.
+- The minimal version must not consult or download original Xeno-canto audio.
+- Trimmed app audio must be written under a `trimmed` folder so the existing pre-trim normalized/exported clip is preserved.
+- If the local source app audio file does not exist, `export_app_audio.py` must fail with a clear error telling the user to redownload the source audio.
+- Admin trim controls render only for selected clips initially.
+- Reset sets `candidate.segment.status` to `not_set` and clears segment times.
+- Force regeneration is explicit with `--force-audio`.
+- If manual trim metadata exists but a trimmed output is skipped because `--force-audio` was not provided, export prints a warning.
+- Admin should allow playing the selected segment.
+
+## Proposed Breakdown
+
+1. **Persist manual trims from selected admin clips**: AFK, unblocked, covers save/validation/reload path.
+2. **Reset trims and play selected segment in admin**: AFK, blocked by Issue 1, covers reset and preview loop.
+3. **Export trimmed clips to preserved-output folder**: AFK, blocked by Issue 1, creates `export_app_audio.py` and trim generation path.
+4. **Generate trim-aware app manifest references**: AFK, blocked by Issue 3, makes BeakSpeak consume trimmed assets only when manual trims exist.
+5. **Handle missing source files and skipped stale trims clearly**: AFK, blocked by Issue 3, adds failure/warning behavior and tests.
+6. **Wire docs and command guidance for the new workflow**: AFK, blocked by Issues 1-5, makes the workflow discoverable.
+
+---
+
+## Issue 1: Persist Manual Trims From Selected Admin Clips
+
+**Type**: AFK
+**Blocked by**: None — can start immediately
+
+### Parent PRD
+
+`export-to-app-nondestructive-audio-trim-prd-2026-04-24-1337.md`
+
+### What to build
+
+Add the first vertical slice for manual trim persistence. Selected clip cards in the admin panel should show simple numeric start/end controls. Saving those controls should persist a manual `candidate.segment` on the matching candidate record. The backend should validate structural correctness before saving. Existing BirdNET metadata, selected role, and audio URL metadata must remain unchanged.
+
+Trim controls should only appear when `selected_role` is `song` or `call`. Non-selected candidates should keep the current role-selection experience without trim controls.
+
+### How to verify
+
+- **Manual**: Start the admin server, select a clip as `song` or `call`, enter a valid start/end trim, save it, reload the admin page, and confirm the trim values are still visible on that selected clip.
+- **Manual**: Confirm non-selected clips do not show trim controls.
+- **Manual**: Confirm saving a trim does not change the selected role or BirdNET evidence shown for the clip.
+- **Automated**: Test that the segment persistence endpoint saves `status: "manual"`, `start_s`, `end_s`, and `duration_s` for the correct candidate.
+- **Automated**: Test that invalid structural payloads are rejected and do not mutate the candidate record.
+
+### Acceptance criteria
+
+- [x] Given a selected clip, when the curator saves a valid start/end trim, then the matching candidate stores a manual segment with computed duration.
+- [x] Given a non-selected clip, when the admin renders the clip card, then trim controls are not shown.
+- [x] Given invalid trim input such as non-numeric values or `start_s >= end_s`, when the curator saves, then the server rejects the request and preserves the previous candidate state.
+- [x] Given a saved trim, when the admin page reloads, then the saved start/end values are displayed for that selected clip.
+- [x] Given a trim save, then existing `candidate.analysis`, `selected_role`, and candidate identity fields are preserved.
+
+### User stories addressed
+
+- User story 1: Trim silence from selected clips.
+- User story 5: Show saved trim fields after reload.
+- User story 7: Reject invalid trim values.
+
+---
+
+## Issue 2: Reset Trims And Play Selected Segment In Admin
+
+**Type**: AFK
+**Blocked by**: Issue 1
+
+### Parent PRD
+
+`export-to-app-nondestructive-audio-trim-prd-2026-04-24-1337.md`
+
+### What to build
+
+Complete the admin trim editing loop by adding reset and selected-segment playback. Reset should set the candidate segment back to `not_set` and clear segment times. Playing the selected segment should use the existing admin audio preview, seek to the saved or currently entered start time, and stop at the end time.
+
+The admin UX should warn when the entered segment is shorter than 1 second or longer than 20 seconds, but it should not hard-block those values if the segment is otherwise structurally valid.
+
+### How to verify
+
+- **Manual**: Save a trim, click reset, reload the admin page, and confirm the trim is cleared.
+- **Manual**: Enter a segment, click play selected segment, and confirm playback starts near the segment start and stops near the segment end.
+- **Manual**: Enter a segment shorter than 1 second and confirm the admin shows a warning but still allows save.
+- **Manual**: Enter a segment longer than 20 seconds and confirm the admin shows a warning but still allows save.
+- **Automated**: Test reset persistence clears segment status/times.
+- **Automated**: Test duration-warning state for under-1-second and over-20-second segments if the admin state logic is testable outside browser E2E.
+
+### Acceptance criteria
+
+- [x] Given a selected clip with a manual trim, when the curator resets it, then the candidate segment becomes `not_set` and segment times are cleared.
+- [x] Given a selected clip with a start/end trim, when the curator plays the selected segment, then playback seeks to the start and stops at the end.
+- [x] Given a segment shorter than 1 second, then the admin warns but does not hard-block save.
+- [x] Given a segment longer than 20 seconds, then the admin warns but does not hard-block save.
+
+### User stories addressed
+
+- User story 6: Reset a manual trim.
+- User story 1: Trim and preview the useful vocalization.
+- User story 7: Handle validation and edge cases predictably.
+
+---
+
+## Issue 3: Export Trimmed Clips To Preserved-Output Folder
+
+**Type**: AFK
+**Blocked by**: Issue 1
+
+### Parent PRD
+
+`export-to-app-nondestructive-audio-trim-prd-2026-04-24-1337.md`
+
+### What to build
+
+Create `export_app_audio.py` as the explicit app-audio export command for manual trims. For candidates with manual segment metadata, the command should read the existing normalized app audio from `beakspeak/public/content/audio/{species}/{xc_id}.ogg`, apply the manual trim window, normalize/encode the trimmed result as needed, and write the generated output under a `trimmed` folder.
+
+The command must preserve the pre-trim source app audio. It must not overwrite `beakspeak/public/content/audio/{species}/{xc_id}.ogg` while creating a trimmed result. It must not consult or download original Xeno-canto audio.
+
+A safe implementation should write to a temporary file first, then replace the trimmed output only after FFmpeg succeeds.
+
+### How to verify
+
+- **Manual**: Save a manual trim for a selected clip, run `export_app_audio.py --force-audio`, and confirm a trimmed `.ogg` appears under the species `trimmed` folder.
+- **Manual**: Confirm the original pre-trim `.ogg` still exists and is unchanged.
+- **Manual**: Listen to the trimmed output and confirm it corresponds to the saved start/end window.
+- **Automated**: Test that manual segment metadata causes export to invoke FFmpeg with the expected trim window using the existing local app audio file as input.
+- **Automated**: Test that the source and destination paths are different and the original file is not overwritten.
+
+### Acceptance criteria
+
+- [x] Given a selected clip with manual segment metadata and existing local app audio, when `export_app_audio.py --force-audio` runs, then a trimmed app audio file is written under a `trimmed` folder.
+- [x] Given a manual trim export, then the pre-trim local app audio file remains in place.
+- [x] Given a manual trim export, then the command does not request or download original Xeno-canto audio.
+- [x] Given FFmpeg failure, then no partial trimmed output replaces a previously valid trimmed file.
+
+### User stories addressed
+
+- User story 8: Exported app audio updates after trim changes.
+- User story 12: Original candidate audio is treated as source material.
+- User story 13: App audio is generated output.
+
+---
+
+## Issue 4: Generate Trim-Aware App Manifest References
+
+**Type**: AFK
+**Blocked by**: Issue 3
+
+### Parent PRD
+
+`export-to-app-nondestructive-audio-trim-prd-2026-04-24-1337.md`
+
+### What to build
+
+Extend the app export command so the BeakSpeak app consumes trimmed audio only for candidates with manual trims. Untrimmed selected clips should continue to use the current selected-audio behavior and existing app audio URL. Manually trimmed clips should reference the generated file under the `trimmed` folder in the app manifest.
+
+This slice should preserve commercial export behavior: export mode determines which selected clips appear in the manifest, while manual trim metadata determines which generated audio path those selected clips use.
+
+### How to verify
+
+- **Manual**: Save a manual trim, run app export, inspect `manifest.json`, and confirm that clipped candidate references the `trimmed` audio URL.
+- **Manual**: Confirm a selected clip without manual trim still references the normal app audio URL.
+- **Manual**: Build or run the app and confirm the manually trimmed clip plays through the normal app audio path.
+- **Automated**: Test manifest generation for one manual-trimmed selected clip and one untrimmed selected clip.
+- **Automated**: Test commercial export mode still filters/substitutes selected clips according to existing behavior.
+
+### Acceptance criteria
+
+- [x] Given a selected clip with manual trim metadata, when app export writes the manifest, then the clip audio URL points to the trimmed generated file.
+- [x] Given a selected clip without manual trim metadata, when app export writes the manifest, then the clip uses the current normal app audio URL behavior.
+- [x] Given commercial export mode, when app export runs, then existing commercial selection behavior is preserved while trim-aware URLs are still applied.
+- [x] Given the app loads the generated manifest, then it can play trimmed and untrimmed selected clips without runtime trimming.
+
+### User stories addressed
+
+- User story 10: App loads short normalized audio.
+- User story 11: Player does not download full candidate recordings.
+- User story 19: Commercial export rules continue applying.
+
+---
+
+## Issue 5: Handle Missing Source Files And Skipped Stale Trims Clearly
+
+**Type**: AFK
+**Blocked by**: Issue 3
+
+### Parent PRD
+
+`export-to-app-nondestructive-audio-trim-prd-2026-04-24-1337.md`
+
+### What to build
+
+Add clear operational failure and warning behavior to `export_app_audio.py`. If a candidate has manual trim metadata but the expected existing local app audio file is missing, the command should fail with a clear error telling the user to redownload the source audio. It should not fall back to Xeno-canto download.
+
+If manual trim metadata exists and a trimmed output already exists, but `--force-audio` is not provided, the command should skip regeneration and print a warning that the existing trimmed output may be stale.
+
+### How to verify
+
+- **Manual**: Temporarily move a source app audio file for a manually trimmed candidate, run export, and confirm the command fails with a clear redownload-source-audio message.
+- **Manual**: Create a manual trim, ensure a trimmed output exists, change the trim metadata, run export without `--force-audio`, and confirm a stale-skip warning is printed.
+- **Automated**: Test missing local source app audio returns a non-zero failure and clear error message.
+- **Automated**: Test manual trim plus existing trimmed output without `--force-audio` prints a warning and does not regenerate.
+
+### Acceptance criteria
+
+- [x] Given manual trim metadata and a missing local source app audio file, when export runs, then it fails clearly and tells the user to redownload the source audio.
+- [x] Given manual trim metadata and an existing trimmed output, when export runs without `--force-audio`, then it skips regeneration and prints a stale-output warning.
+- [x] Given the same state with `--force-audio`, when export runs, then it regenerates the trimmed output.
+- [x] Given a missing local source file, then export does not consult or download original Xeno-canto audio.
+
+### User stories addressed
+
+- User story 16: Force/regenerate mode updates existing app assets.
+- User story 17: Export skips unchanged work when safe.
+- User story 18: Failed source audio reads produce explicit errors.
+
+---
+
+## Issue 6: Document The New Trim Export Workflow
+
+**Type**: AFK
+**Blocked by**: Issue 1, Issue 2, Issue 3, Issue 4, Issue 5
+
+### Parent PRD
+
+`export-to-app-nondestructive-audio-trim-prd-2026-04-24-1337.md`
+
+### What to build
+
+Update project documentation and command guidance so the new workflow is discoverable. The documentation should explain that admin trims are metadata, that source app audio is preserved, that trimmed app audio is generated under a `trimmed` folder, and that `export_app_audio.py --force-audio` is required to regenerate existing trimmed outputs after changing trims.
+
+This issue should also document the failure mode for missing local app audio: the user should rerun the existing media download/normalization step to restore source app audio before exporting trims.
+
+### How to verify
+
+- **Manual**: Read the updated docs and follow the documented path from saving a trim in admin to regenerating trimmed app audio and loading the app manifest.
+- **Manual**: Confirm the docs make it clear that original Xeno-canto audio is not downloaded by the minimal trim export path.
+- **Automated**: Run any docs-adjacent command examples that are practical and cheap, such as command help output if `export_app_audio.py --help` is implemented.
+
+### Acceptance criteria
+
+- [x] Given a new maintainer, when they read the docs, then they can identify the difference between existing app source audio and trimmed generated app audio.
+- [x] Given a curator changes a trim, when they read the docs, then they know to run `export_app_audio.py --force-audio` to regenerate trimmed output.
+- [x] Given export fails because local app audio is missing, when the user reads the docs, then they know which existing source-audio regeneration step to run.
+- [x] Given the minimal scope, then the docs state that full Xeno-canto source downloads and BirdNET re-analysis are out of scope.
+
+### User stories addressed
+
+- User story 14: Separate app export from source download conceptually.
+- User story 20: Tests and workflow prevent accidental destructive behavior.
+- User story 25: Generated app assets are replaceable.
+
+---

--- a/rpi/plans/export-to-app-nondestructive-audio-trim-prd-2026-04-24-1337.md
+++ b/rpi/plans/export-to-app-nondestructive-audio-trim-prd-2026-04-24-1337.md
@@ -1,0 +1,150 @@
+# PRD: Non-Destructive Audio Trim Export To App
+
+## Problem Statement
+
+The current audio pipeline mixes two responsibilities: obtaining candidate audio for curation and producing normalized audio assets for the BeakSpeak app. This makes manual trimming feel risky because it is not obvious whether a trim will alter the original audio, overwrite useful source material, or only affect generated app assets.
+
+The immediate user need is narrower than a full audio-pipeline redesign. The currently selected clips and existing BirdNET Analyzer metadata are mostly useful. The missing capability is a safe way to manually remove silence before and after the useful vocalization so the BeakSpeak app plays tighter clips.
+
+The user needs confidence that admin trimming is reversible and non-destructive. A trim should be stored as metadata and applied only during app export. Original candidate audio and existing BirdNET metadata should remain available for review and future decisions.
+
+## Solution
+
+Create a clear non-destructive export boundary.
+
+Admin audio trimming will save start/end metadata on the selected candidate. It will not edit or overwrite original candidate audio. A dedicated app-export step will read the selected candidates, apply any manual trim metadata, normalize the resulting audio, and write generated assets for the BeakSpeak app.
+
+If a selected clip has no manual trim, export uses the current selected-audio behavior. If a selected clip has a manual trim, export generates the app asset from that selected time window. The BeakSpeak app consumes only generated app assets. It does not trim audio at runtime and does not directly mutate or depend on admin source audio.
+
+The export process should be explicit enough that future maintainers can reason about what is source material, what is metadata, and what is generated app output.
+
+## User Stories
+
+1. As a curator, I want to trim silence from a selected clip, so that the BeakSpeak app plays only the useful bird vocalization.
+2. As a curator, I want trimming to be reversible, so that I can recover from a bad trim without losing the original audio.
+3. As a curator, I want trimming to preserve existing BirdNET metadata, so that I can continue using target and overlap species evidence during review.
+4. As a curator, I want untrimmed selected clips to continue exporting as they do today, so that I do not need to manually edit every clip.
+5. As a curator, I want manual trim fields to show the saved start and end values after reload, so that I can trust that my edits persisted.
+6. As a curator, I want to reset a manual trim, so that the selected clip returns to automatic or current default export behavior.
+7. As a curator, I want invalid trim values to be rejected, so that bad metadata does not break export.
+8. As a curator, I want exported app audio to update after I change a trim, so that the app does not keep playing stale generated files.
+9. As a curator, I want clear status when an export asset is stale or regenerated, so that I can verify my trim took effect.
+10. As a player, I want BeakSpeak lessons and quizzes to load short normalized audio, so that practice feels fast and focused.
+11. As a player, I should not download full candidate recordings, so that app load time and bandwidth stay low.
+12. As a maintainer, I want original candidate audio to be treated as source material, so that pipeline changes never destructively alter it.
+13. As a maintainer, I want app audio to be treated as generated output, so that it can be safely regenerated from source material and metadata.
+14. As a maintainer, I want app export to be a separate conceptual step from source download, so that destructive/non-destructive behavior is obvious.
+15. As a maintainer, I want export behavior to be deterministic from candidate metadata, so that repeated exports produce predictable app assets.
+16. As a maintainer, I want export to support a force/regenerate mode, so that changed trim metadata can update existing app assets.
+17. As a maintainer, I want export to skip unchanged work when safe, so that routine exports do not take longer than necessary.
+18. As a maintainer, I want failed source audio reads or downloads to produce explicit errors, so that missing app audio is not silently shipped.
+19. As a maintainer, I want commercial export rules to continue applying at export time, so that app assets respect the requested deployment mode.
+20. As a maintainer, I want tests around trim persistence and export selection behavior, so that future pipeline edits do not accidentally make trimming destructive.
+21. As a maintainer, I want the design to leave room for later source-audio preview and bounded BirdNET analysis, so that this minimal version does not block future improvements.
+22. As a maintainer, I want manual segment metadata to survive future content-population runs, so that curator work is not lost when candidate metadata is refreshed.
+23. As a maintainer, I want app export to prefer manual trim metadata when present, so that curator intent beats automatic heuristics.
+24. As a maintainer, I want app export to fall back safely when no manual trim is present, so that existing clips remain usable without new admin work.
+25. As a maintainer, I want generated app assets to be replaceable, so that a bad export can be fixed by correcting metadata and exporting again.
+
+## Implementation Decisions
+
+- Manual trimming is metadata-only. It records a segment window on the candidate record and never edits original candidate audio in place.
+- The existing candidate segment concept remains the source of truth for final app trim windows.
+- Segment status should distinguish manual curator edits from automatic or unset segments.
+- Existing BirdNET analysis metadata should not be recalculated or discarded as part of manual trim export.
+- App export should be a distinct module or command from source acquisition, even if some shared helper functions remain.
+- The new app-export command should be named `export_app_audio.py`.
+- The app-export step reads selected candidates, resolves the appropriate source audio, applies manual trim metadata when present, normalizes audio, and writes generated app assets.
+- The BeakSpeak app should continue consuming local generated assets rather than remote original URLs.
+- The minimal version should trim the audio clips already available in the current admin workflow. It should not download completely full-length Xeno-canto source recordings.
+- Current admin previews are sufficient for the first implementation. Full original source-audio preview is not required.
+- If no manual trim exists, export should preserve current selected-audio behavior rather than requiring every selected clip to be trimmed.
+- If manual trim exists, export should use that manual window and regenerate the app asset from source audio or equivalent cached source material.
+- Existing generated app assets must not be treated as authoritative source material for future trims. They are outputs, not originals.
+- Export needs a simple regeneration mechanism so a saved trim does not leave stale app audio in place.
+- The first implementation should use explicit force regeneration for correctness. Fingerprint-based skipping can be added later if export time becomes painful.
+- Force regeneration should require an explicit `--force-audio` flag.
+- If a candidate has manual trim metadata and an existing app audio output is skipped because `--force-audio` was not provided, the export command should print a warning.
+- Admin segment editing should start with simple numeric start/end controls and reset behavior. Rich waveform or spectrogram handles are out of scope for the minimal version.
+- Admin trim controls should appear only for selected clips initially.
+- Resetting a manual trim should set the segment back to `not_set` and clear segment times unless prior auto-segment preservation is implemented separately later.
+- Server-side validation must reject structurally invalid segment windows before writing metadata, such as non-numeric values or start values greater than or equal to end values.
+- The admin UX should warn, but not hard-block, when a segment is shorter than 1 second or longer than 20 seconds.
+- Manual segment edits should follow the same persistence pattern as current role assignment: update the candidate in the pool data and save immediately.
+- Future content-population runs should preserve manual segments the same way they preserve other curator decisions.
+- Commercial export mode should affect what app assets are emitted, not whether source material or trim metadata exists.
+- The design should be compatible with a future source-audio cache and future bounded BirdNET analysis, but neither is required for the minimal trim-export feature.
+- If a cache is needed later, use an ignored local cache outside deployed app assets. Do not block the minimal manual-trim feature on finalizing that cache layout.
+
+## Module Design
+
+- **Name**: Segment Persistence
+- **Responsibility**: Save, validate, reset, and reload manual candidate segment metadata.
+- **Interface**: Accepts candidate identity and either a valid start/end segment or a reset request. Reset sets the segment to `not_set` and clears segment times. Returns the updated segment state or a validation/not-found error.
+- **Tested**: yes
+
+- **Name**: Admin Segment Controls
+- **Responsibility**: Let curators view, edit, save, and reset the export segment for a selected candidate.
+- **Interface**: Renders only for selected clips. Reads current segment metadata from candidate data, sends update/reset requests, and updates local UI state after successful persistence. Handles validation errors without corrupting local state.
+- **Tested**: yes, at least for state/persistence behavior where practical
+
+- **Name**: App Audio Exporter
+- **Responsibility**: Generate BeakSpeak app audio assets from selected candidates without modifying source audio.
+- **Interface**: Exposed as `export_app_audio.py`. Takes export mode and regeneration options, including explicit `--force-audio`. Reads selected candidates, resolves source audio, chooses manual segment or fallback behavior, writes normalized app assets, and reports successes/failures/stale updates.
+- **Tested**: yes
+
+- **Name**: Source Audio Resolver
+- **Responsibility**: Provide the exporter with readable original or equivalent source audio for a candidate.
+- **Interface**: Accepts candidate metadata and returns a local readable audio path or a recoverable error. It may download to a temporary or cache location, but must not overwrite generated app assets as if they were source.
+- **Tested**: yes
+
+- **Name**: Export Freshness Policy
+- **Responsibility**: Decide whether an existing generated app asset can be reused or must be regenerated.
+- **Interface**: Accepts candidate metadata, current segment state, export options, and existing output metadata if available. Returns regenerate or skip. The initial interface can be simple force-or-skip behavior, with warnings when manual trims exist but existing outputs are skipped without `--force-audio`.
+- **Tested**: yes
+
+- **Name**: Manifest Builder Integration
+- **Responsibility**: Ensure the generated app manifest references the correct exported app audio assets after trim-aware export.
+- **Interface**: Accepts selected/exported candidate data and produces manifest audio references consistent with generated files and export mode.
+- **Tested**: yes
+
+## Testing Decisions
+
+- Test external behavior rather than implementation details: a manual segment saved in admin should result in app export using that segment, without altering source audio metadata.
+- Add persistence tests for valid segment save, invalid segment rejection, candidate not found, and reset behavior.
+- Add export tests for three paths: no manual segment uses current fallback behavior, manual segment uses the specified window, and force regeneration updates an existing app asset.
+- Add an export test that a manual trim with an existing output prints a warning when skipped without `--force-audio`.
+- Add a test that generated app assets are treated as outputs and not as source records that overwrite candidate audio metadata.
+- Add a test that manual segment metadata survives normalization of candidate records and reuse from prior pool data.
+- Add a manifest/export test confirming selected candidates still resolve to generated app asset URLs after export.
+- Use existing admin role-assignment persistence tests or patterns as reference for segment persistence tests.
+- Use existing content-pipeline tests around candidate normalization, export audio selection, and segment preservation as reference where available.
+- Do not add end-to-end browser tests for the first PR unless the UI behavior becomes complex enough that unit-level confidence is insufficient.
+
+## Out of Scope
+
+- Running BirdNET Analyzer again.
+- Adding bounded BirdNET analysis windows.
+- Adding multiple analysis windows per candidate.
+- Adding full source-audio review to the admin panel.
+- Downloading completely full-length Xeno-canto source audio for all candidates.
+- Adding waveform or spectrogram drag handles.
+- Adding interactive `Analyze selected range` behavior.
+- Redesigning ranking, candidate discovery, or role assignment.
+- Changing spaced repetition, lesson generation, quiz behavior, or React app playback logic beyond consuming generated assets.
+- Implementing a complex export fingerprint system in the first version.
+- Moving all media pipeline responsibilities into a new architecture in one step.
+- Making the deployed app reference remote Xeno-canto URLs directly.
+- Committing source audio cache files to the repository.
+
+## Open Questions
+
+- None for the minimal version. Prior open questions have been resolved into implementation decisions.
+
+## Further Notes
+
+The core principle is that manual trim is an instruction for export, not an edit to the recording. Original candidate audio should remain recoverable from source metadata or a local source cache. Generated app audio should be disposable and reproducible.
+
+This PRD intentionally scopes back from a broader source-audio plus bounded-BirdNET redesign. That broader design remains useful, but the minimal safe path is to make trim metadata explicit, make app export consume that metadata, and make regeneration obvious.
+
+A future phase can introduce full source-audio preview, bounded FFmpeg-selected BirdNET analysis windows, and richer timeline overlays. Those features should build on the same separation: source audio for review, metadata for decisions, generated audio for the app.

--- a/rpi/research/admin-audio-segmentation-options-2026-04-24-1308.md
+++ b/rpi/research/admin-audio-segmentation-options-2026-04-24-1308.md
@@ -1,0 +1,364 @@
+# Admin Audio Segmentation Options
+
+Timestamp: 2026-04-24 13:08 America/Los_Angeles
+
+## Context
+
+Issue #23 proposes improving BeakSpeak's admin audio trimming workflow. The current system already has a persisted `candidate.segment` concept and `download_media.py` honors stored segment windows during normalization/export. The gap is that curators cannot edit those windows in the admin panel, and the fallback trimming path can choose poor regions when useful vocalizations appear later in a recording.
+
+The product needs two different audio experiences:
+
+- Admin curation: review enough source audio to make an informed choice, including silence, context, competing species, and BirdNET evidence.
+- App runtime: ship only short normalized clips for selected song/call assets.
+
+These should not be forced into one audio artifact.
+
+## Recommended Direction
+
+Separate the audio pipeline into three concepts:
+
+1. `source_audio`: full candidate audio cached locally for admin review only.
+2. `analysis_window`: a bounded region, usually 20-30 seconds, selected cheaply by FFmpeg and optionally analyzed by BirdNET Analyzer.
+3. `segment`: the final export window used by the BeakSpeak app, targeting 2-5 seconds.
+
+This keeps the admin panel information-rich without requiring the app to ship large files. It also caps BirdNET runtime by analyzing short candidate windows rather than entire long recordings.
+
+Suggested data shape:
+
+```json
+{
+  "source_audio": {
+    "status": "cached",
+    "local_path": "admin/source-audio/american-robin/123456.mp3",
+    "duration_s": 82.4
+  },
+  "analysis_window": {
+    "status": "ffmpeg_energy_window",
+    "start_s": 42.5,
+    "end_s": 72.5,
+    "duration_s": 30.0
+  },
+  "analysis": {
+    "status": "analyzed",
+    "provider": "birdnet",
+    "window_start_s": 42.5,
+    "target_detections": [],
+    "overlap_detections": []
+  },
+  "segment": {
+    "status": "manual",
+    "start_s": 48.2,
+    "end_s": 58.2,
+    "duration_s": 10.0
+  }
+}
+```
+
+BirdNET detections should be converted to full-source timestamps where practical. If detections remain relative to the extracted analysis clip, the payload must make that explicit and the admin UI must offset them consistently.
+
+## Option 0: Manual Trim Existing Selected Clips
+
+Value: High
+Complexity: Low
+
+This is the smallest useful scope if the currently selected clips and existing BirdNET metadata are mostly good. The goal is not to improve candidate discovery or re-run analysis. The goal is only to remove unwanted silence before and after the good part of already-selected audio for the final BeakSpeak app export.
+
+### What Changes
+
+- Add simple start/end trim controls in the admin panel for selected candidate clips.
+- Persist manual trims to the existing `candidate.segment` field with `status: "manual"`.
+- Add `reset trim` or `reset to auto` to clear manual segment overrides.
+- Keep existing `candidate.analysis` BirdNET metadata unchanged.
+- Keep current selected song/call choices unchanged.
+- Confirm `download_media.py` gives manual `candidate.segment` precedence during export.
+- Add a minimal `--force-audio` or equivalent regeneration path so existing exported `.ogg` files update after trim changes.
+
+### What Does Not Change
+
+- Do not add source-audio caching yet.
+- Do not add `analysis_window` yet.
+- Do not re-run BirdNET Analyzer.
+- Do not add full waveform/spectrogram editing yet.
+- Do not add interactive `Analyze selected range`.
+- Do not redesign the asset pipeline into separate admin source and app export stores yet.
+
+### Benefits
+
+- Directly addresses the immediate problem: good clips with extra silence.
+- Reuses the current selected clips and BirdNET metadata.
+- Builds on existing `candidate.segment` support rather than adding a new data model.
+- Low implementation risk because it mirrors the existing role-assignment persistence pattern.
+- Creates a foundation for richer manual segment editing later.
+
+### Costs / Risks
+
+- Curators can only trim what they can currently preview. If the admin is previewing already-normalized output, this does not recover useful audio outside that file.
+- Does not improve bad automatic candidate choices.
+- Does not reduce BirdNET runtime.
+- Needs export invalidation; otherwise saved trims may not be reflected when existing app audio files are skipped.
+
+### Best Fit
+
+Choose this first if current selected clips are mostly good and the near-term need is only to tighten app audio segments.
+
+## Option 1: Manual Segment Editor + Full Source Cache
+
+Value: High
+Complexity: Medium
+
+Build the workflow around human curation first.
+
+### What Changes
+
+- Cache full candidate audio files for admin review in a local-only directory outside deployed app assets.
+- Admin panel previews full source audio.
+- Add segment start/end controls to each candidate card.
+- Persist manual windows to `candidate.segment` with `status: "manual"`.
+- Add `reset to auto` to clear manual segment and return to heuristic behavior.
+- Exporter generates app audio only for selected candidates, using persisted `candidate.segment`.
+
+### Benefits
+
+- Directly solves the core curation problem.
+- Keeps the app bundle small.
+- Avoids making BirdNET required for basic curation.
+- Lowest risk path to useful admin improvements.
+
+### Costs / Risks
+
+- Does not improve automated suggestions much by itself.
+- Curators may spend more time manually finding the right vocalization in long recordings.
+- Needs clear cache/export invalidation so changed segments regenerate app audio.
+
+### Best Fit
+
+Choose this if the immediate priority is reliable curator control and smaller shipped assets.
+
+## Option 2: FFmpeg Analysis Window + BirdNET On Bounded Clips
+
+Value: High
+Complexity: Medium-High
+
+Use FFmpeg as a cheap preselector, then run BirdNET only on a short extracted window.
+
+### What Changes
+
+- Run FFmpeg silence/energy detection across full source audio.
+- Select one 20-30 second `analysis_window`, using longest/loudest active region with padding.
+- Extract that window to a temporary file.
+- Run BirdNET Analyzer only on that extracted file.
+- Persist `analysis_window` and BirdNET target/overlap metadata.
+- Admin panel shows full source audio, analysis window overlay, BirdNET detections, and editable final segment overlay.
+
+### Benefits
+
+- Preserves useful BirdNET metadata without analyzing every second of every source recording.
+- Keeps runtime bounded: 450 candidates means at most roughly 450 x 20-30 seconds of BirdNET input.
+- Gives curators better evidence than waveform/silence detection alone.
+- Maintains separation between analysis and final export segment.
+
+### Costs / Risks
+
+- FFmpeg can choose the wrong analysis window, causing BirdNET to miss the best vocalization.
+- Requires more UI state: source audio, analysis window, detections, final segment.
+- Requires careful timestamp handling between extracted clip time and full source time.
+- Still adds BirdNET runtime, though much less than full-file analysis.
+
+### Best Fit
+
+Choose this if BirdNET evidence is important during review but pipeline runtime must remain controlled.
+
+## Option 2A: Lean Bounded BirdNET Analysis
+
+Value: High
+Complexity: Medium
+
+This is the recommended 80/20 path if Option 2 feels too much like a redesign. Keep the current pipeline concepts mostly intact, but reduce BirdNET cost by inserting a short FFmpeg-selected analysis window before BirdNET runs.
+
+### What Changes
+
+- Keep `candidate.analysis` as the place where BirdNET target and overlap detections live.
+- Keep `candidate.segment` as the final export window.
+- Add only one lightweight metadata object, either `candidate.analysis_window` or `candidate.analysis.window`.
+- Use FFmpeg to select a 20-30 second window before running BirdNET.
+- Run BirdNET on that extracted window instead of the whole source file.
+- Convert BirdNET timestamps back to original source-audio timestamps before saving.
+- Admin initially displays the analysis window and evidence as read-only metadata; manual segment editing can come later or remain numeric-only at first.
+
+### What Does Not Change
+
+- Do not introduce multiple source/export asset types in the first pass.
+- Do not support multiple analysis windows yet.
+- Do not add interactive `Analyze selected range` yet.
+- Do not build a full waveform/spectrogram editor yet.
+- Do not make the admin server regenerate exports immediately.
+
+### Benefits
+
+- Gets most BirdNET runtime savings without reworking the whole admin architecture.
+- Preserves the useful target/overlap metadata curators already value.
+- Keeps the current persisted `analysis` and `segment` responsibilities understandable.
+- Creates a migration path to full Option 2 later.
+
+### Costs / Risks
+
+- Admin review may still depend on existing normalized audio unless source-audio preview is added separately.
+- If FFmpeg chooses the wrong 20-30 second window, BirdNET evidence may miss the best vocalization.
+- The model still needs clear timestamp semantics.
+
+### Best Fit
+
+Choose this as the next implementation step if the goal is maximum BirdNET value with minimum disruption.
+
+## Option 3: Interactive Admin-Driven Analysis
+
+Value: Very High
+Complexity: High
+
+Make BirdNET analysis a curator-triggered action rather than a batch default.
+
+### What Changes
+
+- Start with Option 1 or Option 2 basics.
+- Admin panel lets curator select a region and click `Analyze selected range`.
+- Server extracts the selected range and runs BirdNET on demand.
+- Persist one or more analysis windows per candidate.
+- Admin displays previous analysis windows and detections.
+- Optional: allow promoting an analyzed detection region into the final export `segment`.
+
+### Benefits
+
+- Avoids wasting BirdNET time on low-value clips.
+- Curator can recover when automatic FFmpeg window selection is wrong.
+- Supports deeper review of difficult candidates with overlap species or uncertain calls.
+- Scales better as candidate count grows because analysis becomes targeted.
+
+### Costs / Risks
+
+- More backend orchestration in the local admin server.
+- UI is more complex: region selection, progress state, errors, multiple analysis results.
+- BirdNET execution latency becomes part of the curator's interactive workflow.
+- Needs robust locking/status handling so repeated clicks or failed runs do not corrupt state.
+
+### Best Fit
+
+Choose this after the basic curation workflow is working, especially if curators frequently need BirdNET on a different window than the automated choice.
+
+## Recommended Implementation Sequence
+
+1. Implement Option 0 first if current selected clips are mostly good: manual trim existing selected clips, persist to `candidate.segment`, and add export regeneration.
+2. Add source-audio preview only if curators cannot make good trim decisions from the current admin preview.
+3. Implement Option 2A next if BirdNET runtime or analysis freshness becomes the bottleneck: bounded BirdNET analysis using a persisted analysis window.
+4. Add minimal admin visibility for the analysis window so curators know what BirdNET reviewed.
+5. Add full Option 2 overlays or Option 3 interactive analysis only if real curation shows that the lean path misses too often.
+
+This sequence avoids overbuilding while preserving a clear path to richer BirdNET-assisted review. It also avoids committing immediately to a larger admin redesign.
+
+## Pipeline Notes
+
+### Source Audio Cache
+
+Full candidate audio should be local-only and not deployed with the app. Candidate files can be keyed by species and Xeno-canto ID, for example:
+
+```text
+admin/source-audio/{species_id}/{xc_id}.{ext}
+```
+
+The admin server can serve these files at an endpoint such as:
+
+```text
+/source-audio/{species_id}/{xc_id}
+```
+
+The deployed app should continue reading only from `beakspeak/public/content/audio`.
+
+### Export Audio
+
+The export step should only produce normalized app clips for selected candidates. It should use this precedence:
+
+1. Manual `candidate.segment` if present.
+2. Persisted auto `candidate.segment` if present.
+3. FFmpeg fallback segment.
+4. Default first 20 seconds only as a last resort.
+
+The exporter also needs invalidation. If an output file already exists but the selected segment changed, it must regenerate. Possible approaches:
+
+- Add `--force-audio`.
+- Store a sidecar manifest with source URL, segment start/end, and export parameters.
+- Compare current candidate segment to a previous export fingerprint.
+- Delete/regenerate only the affected candidate from admin after saving a segment.
+
+The sidecar/fingerprint approach is the most robust long-term option.
+
+### BirdNET Runtime Control
+
+BirdNET should not run on every full source file by default. Suggested controls:
+
+- `--analyze-missing-only`
+- `--species american-robin`
+- `--xc-id 123456`
+- `--limit 20`
+- `--analysis-window-duration 30`
+- `--force-analysis`
+
+Persist enough metadata to skip re-analysis unless the source audio or analysis window changes.
+
+### FFmpeg Window Selection
+
+The current `download_media.py` fallback should not select the first non-silent segment of sufficient duration. Better heuristics:
+
+- Find all active regions using `silencedetect`.
+- Prefer high-energy or long active regions.
+- Apply padding.
+- Clamp to a 20-30 second analysis window.
+- Avoid choosing tiny loud noise bursts by requiring minimum active duration.
+
+If possible, centralize this logic with the existing segment selection utilities in `populate_content.py` rather than maintaining divergent heuristics in multiple files.
+
+## Admin UI Notes
+
+The admin panel should distinguish overlays visually:
+
+- Source audio duration: full waveform/progress track.
+- Analysis window: shaded region showing what BirdNET analyzed.
+- BirdNET detections: markers or bands within the analysis window.
+- Export segment: editable start/end handles.
+
+Minimum viable controls:
+
+- Numeric start/end fields.
+- Save segment.
+- Reset to auto.
+- Play full source.
+- Play selected segment preview.
+
+Better controls:
+
+- Drag handles on a waveform or spectrogram.
+- Jump-to-detection controls from BirdNET evidence.
+- Analyze selected range.
+
+## Open Questions
+
+1. Where should full source audio live?
+   Recommendation: use an ignored cache outside deployed app assets, preferably `.cache/beakspeak/source-audio/{species_id}/{xc_id}.{ext}`. This avoids confusing source assets with app-shipped assets and keeps `admin/` mostly source code.
+2. Should source audio files be committed, ignored, or always reconstructed from Xeno-canto URLs?
+   Recommendation: ignore them and reconstruct from Xeno-canto URLs when needed. Commit only metadata, segment choices, and analysis results. Audio cache should be treated as a local build artifact.
+3. Should `analysis_window` support only one window initially, or should the model allow multiple windows from the start?
+   Recommendation: support one window initially. Use a single object, not an array. Multiple windows add UI and persistence complexity before there is evidence they are needed.
+4. Should manual segment editing clamp to a fixed app duration target, or allow variable durations up to a max such as 20 seconds?
+   Recommendation: allow variable durations, but validate with a minimum and maximum. Given the current target is 2-5 seconds, default new manual selections to 5 seconds and warn or require confirmation above 10 seconds. Hard cap at 20 seconds unless there is a specific training reason to exceed it.
+5. Should BirdNET detections be stored as full-source timestamps or analysis-window-relative timestamps?
+   Recommendation: store full-source timestamps for detections and also store `analysis_window.start_s`. Full-source timestamps simplify admin overlays and future manual segment editing. Keeping the window start preserves traceability to the extracted BirdNET input.
+6. Should the admin server regenerate exported app audio immediately after segment save, or should export remain a separate explicit command?
+   Recommendation: keep export as a separate explicit command for now. Add visible stale/export-needed state later if needed. Immediate regeneration increases admin server responsibility and can hide slow or failing FFmpeg work inside a UI save action.
+7. What is the acceptable upper bound for BirdNET batch runtime during normal curation: minutes, tens of minutes, or overnight?
+   Recommendation: target single-digit minutes for normal incremental runs and make longer analysis explicitly opt-in. The default should be `missing-only` bounded-window analysis with species/clip filters. Full refresh can be allowed as an intentional overnight-style command, not the normal path.
+8. Should commercial export mode affect which source candidates are cached/analyzed, or only which selected candidates are shipped?
+   Recommendation: only affect what ships. Cache and analyze all useful candidates for curation unless disk/runtime pressure becomes a real problem. Curators may need non-commercial candidates as reference/context even if they are excluded from commercial export.
+
+## Recommendation
+
+Use Option 0 as the near-term path if the current selected clips are mostly good. It captures the immediate value with the least new architecture: persist manual trims to `candidate.segment`, keep existing BirdNET metadata, and regenerate exported app audio when trims change.
+
+If review shows that current previews are not enough context, add source-audio preview. If BirdNET runtime or stale analysis becomes the next bottleneck, move to Option 2A. Keep full Option 2 and interactive `Analyze selected range` as later enhancements if automated window selection proves unreliable.

--- a/test_admin_server.py
+++ b/test_admin_server.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from admin.server import persist_candidate_role_assignment
+from admin.server import persist_candidate_role_assignment, persist_candidate_segment, reset_candidate_segment
 from populate_content import load_pool_file, save_pool_file
 
 
@@ -30,6 +30,7 @@ def _write_pool(path: Path) -> None:
                                 "source_role": "call",
                                 "selected_role": "call",
                                 "type": "call",
+                                "analysis": {"status": "ok", "summary": {"target_detection_count": 1}},
                             },
                         ],
                     },
@@ -78,3 +79,132 @@ def test_persist_candidate_role_assignment_rejects_unknown_role(tmp_path: Path):
             xc_id="1",
             selected_role="duet",
         )
+
+
+def test_persist_candidate_segment_saves_manual_trim_without_changing_candidate_metadata(tmp_path: Path):
+    pool_file = tmp_path / "pool.json"
+    _write_pool(pool_file)
+
+    updated = persist_candidate_segment(
+        pool_file=pool_file,
+        species_id="sp1",
+        candidate_id="xc:2:call:0",
+        xc_id="2",
+        start_s=1.25,
+        end_s=6.75,
+    )
+
+    assert updated["selected_role"] == "call"
+    assert updated["analysis"] == {
+        "status": "ok",
+        "provider": None,
+        "target_detections": [],
+        "overlap_detections": [],
+        "summary": {"target_detection_count": 1},
+        "failure": None,
+    }
+    assert updated["candidate_id"] == "xc:2:call:0"
+    assert updated["xc_id"] == "2"
+    assert updated["segment"] == {
+        "status": "manual",
+        "start_s": 1.25,
+        "end_s": 6.75,
+        "duration_s": 5.5,
+        "confidence": None,
+        "fallback_reason": None,
+    }
+
+    reloaded = load_pool_file(pool_file)
+    persisted_segment = reloaded["species"][0]["audio_clips"]["candidates"][1]["segment"]
+    assert persisted_segment["status"] == "manual"
+    assert persisted_segment["start_s"] == 1.25
+    assert persisted_segment["end_s"] == 6.75
+    assert persisted_segment["duration_s"] == 5.5
+
+
+@pytest.mark.parametrize(
+    ("start_s", "end_s", "message"),
+    [
+        ("nope", 3.0, "numeric"),
+        (5.0, 5.0, "less than end_s"),
+        (6.0, 5.0, "less than end_s"),
+        (-1.0, 5.0, "greater than or equal to 0"),
+    ],
+)
+def test_persist_candidate_segment_rejects_invalid_trim_without_mutating_existing_segment(
+    tmp_path: Path,
+    start_s,
+    end_s,
+    message: str,
+):
+    pool_file = tmp_path / "pool.json"
+    _write_pool(pool_file)
+    persist_candidate_segment(
+        pool_file=pool_file,
+        species_id="sp1",
+        candidate_id="xc:2:call:0",
+        xc_id="2",
+        start_s=1.0,
+        end_s=4.0,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        persist_candidate_segment(
+            pool_file=pool_file,
+            species_id="sp1",
+            candidate_id="xc:2:call:0",
+            xc_id="2",
+            start_s=start_s,
+            end_s=end_s,
+        )
+
+    reloaded = load_pool_file(pool_file)
+    segment = reloaded["species"][0]["audio_clips"]["candidates"][1]["segment"]
+    assert segment["status"] == "manual"
+    assert segment["start_s"] == 1.0
+    assert segment["end_s"] == 4.0
+
+
+def test_persist_candidate_segment_rejects_non_selected_clip(tmp_path: Path):
+    pool_file = tmp_path / "pool.json"
+    _write_pool(pool_file)
+
+    with pytest.raises(ValueError, match="selected"):
+        persist_candidate_segment(
+            pool_file=pool_file,
+            species_id="sp1",
+            candidate_id="xc:1:song:0",
+            xc_id="1",
+            start_s=1.0,
+            end_s=3.0,
+        )
+
+
+def test_reset_candidate_segment_clears_manual_trim(tmp_path: Path):
+    pool_file = tmp_path / "pool.json"
+    _write_pool(pool_file)
+    persist_candidate_segment(
+        pool_file=pool_file,
+        species_id="sp1",
+        candidate_id="xc:2:call:0",
+        xc_id="2",
+        start_s=1.0,
+        end_s=4.0,
+    )
+
+    updated = reset_candidate_segment(
+        pool_file=pool_file,
+        species_id="sp1",
+        candidate_id="xc:2:call:0",
+        xc_id="2",
+    )
+
+    assert updated["selected_role"] == "call"
+    assert updated["segment"] == {
+        "status": "not_set",
+        "start_s": None,
+        "end_s": None,
+        "duration_s": None,
+        "confidence": None,
+        "fallback_reason": None,
+    }

--- a/test_export_app_audio.py
+++ b/test_export_app_audio.py
@@ -1,0 +1,255 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from export_app_audio import export_app_audio
+from populate_content import save_pool_file
+
+
+def _candidate(
+    *,
+    xc_id: str,
+    source_role: str = "song",
+    selected_role: str = "song",
+    commercial_ok: bool = True,
+    segment: dict | None = None,
+    score: float = 50.0,
+) -> dict:
+    return {
+        "candidate_id": f"xc:{xc_id}:{source_role}:0",
+        "xc_id": xc_id,
+        "source_role": source_role,
+        "selected_role": selected_role,
+        "type": source_role,
+        "xc_type": source_role,
+        "audio_url": f"https://xeno-canto.org/{xc_id}.mp3",
+        "license": "https://creativecommons.org/licenses/by/4.0/" if commercial_ok else "https://creativecommons.org/licenses/by-nc/4.0/",
+        "commercial_ok": commercial_ok,
+        "score": score,
+        "segment": segment or {"status": "not_set"},
+    }
+
+
+def _pool(candidates: list[dict]) -> dict:
+    return {
+        "species": [
+            {
+                "id": "warbler",
+                "common_name": "Wilson's Warbler",
+                "scientific_name": "Cardellina pusilla",
+                "audio_clips": {"schema_version": 2, "candidates": candidates},
+                "wikipedia_audio": [],
+                "photo": {"url": "/content/photos/warbler.jpg"},
+            }
+        ]
+    }
+
+
+def test_export_app_audio_generates_manual_trim_from_existing_local_app_audio(tmp_path: Path):
+    pool_file = tmp_path / "pool.json"
+    audio_dir = tmp_path / "audio"
+    manifest_out = tmp_path / "manifest.json"
+    source = audio_dir / "warbler" / "101.ogg"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"source audio")
+    save_pool_file(
+        pool_file,
+        _pool([
+            _candidate(
+                xc_id="101",
+                segment={"status": "manual", "start_s": 1.25, "end_s": 6.75, "duration_s": 5.5},
+            )
+        ]),
+    )
+    calls = []
+
+    def runner(cmd, capture_output, text):
+        del capture_output, text
+        calls.append(cmd)
+        Path(cmd[-1]).write_bytes(b"trimmed audio")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    result = export_app_audio(
+        pool_file=pool_file,
+        audio_dir=audio_dir,
+        manifest_out=manifest_out,
+        force_audio=True,
+        runner=runner,
+    )
+
+    trimmed = audio_dir / "warbler" / "trimmed" / "101.ogg"
+    assert trimmed.read_bytes() == b"trimmed audio"
+    assert source.read_bytes() == b"source audio"
+    assert calls == [[
+        "ffmpeg",
+        "-ss",
+        "1.25",
+        "-t",
+        "5.5",
+        "-i",
+        str(source),
+        "-af",
+        "loudnorm=I=-16:TP=-1.5:LRA=11",
+        "-c:a",
+        "libopus",
+        "-b:a",
+        "96k",
+        "-y",
+        str(trimmed.with_suffix(".tmp.ogg")),
+    ]]
+    assert result["generated"] == [trimmed]
+
+
+def test_export_app_audio_failure_does_not_replace_existing_trimmed_output(tmp_path: Path):
+    pool_file = tmp_path / "pool.json"
+    audio_dir = tmp_path / "audio"
+    source = audio_dir / "warbler" / "101.ogg"
+    trimmed = audio_dir / "warbler" / "trimmed" / "101.ogg"
+    source.parent.mkdir(parents=True)
+    trimmed.parent.mkdir(parents=True)
+    source.write_bytes(b"source audio")
+    trimmed.write_bytes(b"previous good trim")
+    save_pool_file(
+        pool_file,
+        _pool([
+            _candidate(
+                xc_id="101",
+                segment={"status": "manual", "start_s": 1.0, "end_s": 3.0, "duration_s": 2.0},
+            )
+        ]),
+    )
+
+    def runner(cmd, capture_output, text):
+        del capture_output, text
+        Path(cmd[-1]).write_bytes(b"partial")
+        return subprocess.CompletedProcess(cmd, 1, "", "boom")
+
+    with pytest.raises(RuntimeError, match="ffmpeg failed"):
+        export_app_audio(
+            pool_file=pool_file,
+            audio_dir=audio_dir,
+            manifest_out=tmp_path / "manifest.json",
+            force_audio=True,
+            runner=runner,
+        )
+
+    assert trimmed.read_bytes() == b"previous good trim"
+    assert not trimmed.with_suffix(".tmp.ogg").exists()
+
+
+def test_export_app_audio_missing_manual_trim_source_fails_with_redownload_guidance(tmp_path: Path):
+    pool_file = tmp_path / "pool.json"
+    save_pool_file(
+        pool_file,
+        _pool([
+            _candidate(
+                xc_id="101",
+                segment={"status": "manual", "start_s": 1.0, "end_s": 3.0, "duration_s": 2.0},
+            )
+        ]),
+    )
+
+    with pytest.raises(FileNotFoundError, match="redownload the source audio"):
+        export_app_audio(pool_file=pool_file, audio_dir=tmp_path / "audio", manifest_out=tmp_path / "manifest.json")
+
+
+def test_export_app_audio_skips_existing_trim_without_force_and_warns(tmp_path: Path):
+    pool_file = tmp_path / "pool.json"
+    audio_dir = tmp_path / "audio"
+    source = audio_dir / "warbler" / "101.ogg"
+    trimmed = audio_dir / "warbler" / "trimmed" / "101.ogg"
+    source.parent.mkdir(parents=True)
+    trimmed.parent.mkdir(parents=True)
+    source.write_bytes(b"source audio")
+    trimmed.write_bytes(b"old trim")
+    save_pool_file(
+        pool_file,
+        _pool([
+            _candidate(
+                xc_id="101",
+                segment={"status": "manual", "start_s": 1.0, "end_s": 3.0, "duration_s": 2.0},
+            )
+        ]),
+    )
+
+    def runner(cmd, capture_output, text):
+        raise AssertionError(f"ffmpeg should not run: {cmd}")
+
+    result = export_app_audio(
+        pool_file=pool_file,
+        audio_dir=audio_dir,
+        manifest_out=tmp_path / "manifest.json",
+        force_audio=False,
+        runner=runner,
+    )
+
+    assert trimmed.read_bytes() == b"old trim"
+    assert result["generated"] == []
+    assert any("may be stale" in warning for warning in result["warnings"])
+
+
+def test_export_app_audio_writes_trim_aware_manifest_and_preserves_commercial_substitution(tmp_path: Path):
+    pool_file = tmp_path / "pool.json"
+    audio_dir = tmp_path / "audio"
+    manifest_out = tmp_path / "manifest.json"
+    for xc_id in ("101", "102", "103"):
+        source = audio_dir / "warbler" / f"{xc_id}.ogg"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_bytes(f"source {xc_id}".encode())
+
+    save_pool_file(
+        pool_file,
+        _pool([
+            _candidate(
+                xc_id="101",
+                selected_role="song",
+                commercial_ok=False,
+                segment={"status": "manual", "start_s": 1.0, "end_s": 3.0, "duration_s": 2.0},
+                score=90.0,
+            ),
+            _candidate(
+                xc_id="102",
+                selected_role="none",
+                commercial_ok=True,
+                score=80.0,
+            ),
+            _candidate(
+                xc_id="103",
+                source_role="call",
+                selected_role="call",
+                commercial_ok=True,
+                score=70.0,
+            ),
+        ]),
+    )
+
+    def runner(cmd, capture_output, text):
+        del capture_output, text
+        Path(cmd[-1]).write_bytes(b"trimmed")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    result = export_app_audio(
+        pool_file=pool_file,
+        audio_dir=audio_dir,
+        manifest_out=manifest_out,
+        export_mode="commercial",
+        force_audio=True,
+        runner=runner,
+    )
+
+    manifest = result["manifest"]
+    assert [clip["xc_id"] for clip in manifest["species"][0]["audio_clips"]["songs"]] == ["102"]
+    assert manifest["species"][0]["audio_clips"]["songs"][0]["audio_url"] == "/content/audio/warbler/102.ogg"
+    assert manifest["species"][0]["audio_clips"]["calls"][0]["audio_url"] == "/content/audio/warbler/103.ogg"
+
+    all_mode_result = export_app_audio(
+        pool_file=pool_file,
+        audio_dir=audio_dir,
+        manifest_out=manifest_out,
+        export_mode="all",
+        force_audio=False,
+        runner=runner,
+    )
+    all_mode_manifest = all_mode_result["manifest"]
+    assert all_mode_manifest["species"][0]["audio_clips"]["songs"][0]["audio_url"] == "/content/audio/warbler/trimmed/101.ogg"

--- a/test_export_app_audio.py
+++ b/test_export_app_audio.py
@@ -15,9 +15,10 @@ def _candidate(
     commercial_ok: bool = True,
     segment: dict | None = None,
     score: float = 50.0,
+    candidate_id: str | None = None,
 ) -> dict:
     return {
-        "candidate_id": f"xc:{xc_id}:{source_role}:0",
+        "candidate_id": candidate_id or f"xc:{xc_id}:{source_role}:0",
         "xc_id": xc_id,
         "source_role": source_role,
         "selected_role": selected_role,
@@ -78,7 +79,7 @@ def test_export_app_audio_generates_manual_trim_from_existing_local_app_audio(tm
         runner=runner,
     )
 
-    trimmed = audio_dir / "warbler" / "trimmed" / "101.ogg"
+    trimmed = audio_dir / "warbler" / "trimmed" / "xc-101-song-0.ogg"
     assert trimmed.read_bytes() == b"trimmed audio"
     assert source.read_bytes() == b"source audio"
     assert calls == [[
@@ -105,7 +106,7 @@ def test_export_app_audio_failure_does_not_replace_existing_trimmed_output(tmp_p
     pool_file = tmp_path / "pool.json"
     audio_dir = tmp_path / "audio"
     source = audio_dir / "warbler" / "101.ogg"
-    trimmed = audio_dir / "warbler" / "trimmed" / "101.ogg"
+    trimmed = audio_dir / "warbler" / "trimmed" / "xc-101-song-0.ogg"
     source.parent.mkdir(parents=True)
     trimmed.parent.mkdir(parents=True)
     source.write_bytes(b"source audio")
@@ -158,7 +159,7 @@ def test_export_app_audio_skips_existing_trim_without_force_and_warns(tmp_path: 
     pool_file = tmp_path / "pool.json"
     audio_dir = tmp_path / "audio"
     source = audio_dir / "warbler" / "101.ogg"
-    trimmed = audio_dir / "warbler" / "trimmed" / "101.ogg"
+    trimmed = audio_dir / "warbler" / "trimmed" / "xc-101-song-0.ogg"
     source.parent.mkdir(parents=True)
     trimmed.parent.mkdir(parents=True)
     source.write_bytes(b"source audio")
@@ -252,4 +253,55 @@ def test_export_app_audio_writes_trim_aware_manifest_and_preserves_commercial_su
         runner=runner,
     )
     all_mode_manifest = all_mode_result["manifest"]
-    assert all_mode_manifest["species"][0]["audio_clips"]["songs"][0]["audio_url"] == "/content/audio/warbler/trimmed/101.ogg"
+    assert all_mode_manifest["species"][0]["audio_clips"]["songs"][0]["audio_url"] == "/content/audio/warbler/trimmed/xc-101-song-0.ogg"
+
+
+def test_export_app_audio_keys_trimmed_outputs_by_candidate_identity_when_xc_id_is_shared(tmp_path: Path):
+    pool_file = tmp_path / "pool.json"
+    audio_dir = tmp_path / "audio"
+    source = audio_dir / "warbler" / "201.ogg"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"source audio")
+    save_pool_file(
+        pool_file,
+        _pool([
+            _candidate(
+                xc_id="201",
+                source_role="song",
+                selected_role="song",
+                candidate_id="xc:201:song:0",
+                segment={"status": "manual", "start_s": 1.0, "end_s": 3.0, "duration_s": 2.0},
+            ),
+            _candidate(
+                xc_id="201",
+                source_role="call",
+                selected_role="call",
+                candidate_id="xc:201:call:0",
+                segment={"status": "manual", "start_s": 4.0, "end_s": 6.5, "duration_s": 2.5},
+            ),
+        ]),
+    )
+    outputs = []
+
+    def runner(cmd, capture_output, text):
+        del capture_output, text
+        output = Path(cmd[-1])
+        outputs.append(output)
+        output.write_bytes(f"trim {cmd[2]} {cmd[4]}".encode())
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    result = export_app_audio(
+        pool_file=pool_file,
+        audio_dir=audio_dir,
+        manifest_out=tmp_path / "manifest.json",
+        force_audio=True,
+        runner=runner,
+    )
+
+    song_trim = audio_dir / "warbler" / "trimmed" / "xc-201-song-0.ogg"
+    call_trim = audio_dir / "warbler" / "trimmed" / "xc-201-call-0.ogg"
+    assert result["generated"] == [song_trim, call_trim]
+    assert song_trim.read_bytes() == b"trim 1.0 2.0"
+    assert call_trim.read_bytes() == b"trim 4.0 2.5"
+    assert outputs == [song_trim.with_suffix(".tmp.ogg"), call_trim.with_suffix(".tmp.ogg")]
+    assert result["manifest"]["species"][0]["audio_clips"]["songs"][0]["audio_url"] == "/content/audio/warbler/trimmed/xc-201-song-0.ogg"

--- a/tier1_seattle_birds_populated.json
+++ b/tier1_seattle_birds_populated.json
@@ -468,12 +468,12 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_extended_context",
-              "start_s": 0.0,
-              "end_s": 12.0,
-              "duration_s": 12.0,
-              "confidence": 0.983,
-              "fallback_reason": "target_region_requires_more_context"
+              "status": "manual",
+              "start_s": 0.002,
+              "end_s": 4.6,
+              "duration_s": 4.598,
+              "confidence": null,
+              "fallback_reason": null
             },
             "score": 91.5,
             "ranking_signals": {
@@ -556,11 +556,11 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_target_centered",
+              "status": "manual",
               "start_s": 0.0,
-              "end_s": 7.0,
-              "duration_s": 7.0,
-              "confidence": 0.909,
+              "end_s": 3.1,
+              "duration_s": 3.1,
+              "confidence": null,
               "fallback_reason": null
             },
             "score": 91.27,
@@ -3687,11 +3687,11 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_target_centered",
-              "start_s": 0.0,
-              "end_s": 7.0,
-              "duration_s": 7.0,
-              "confidence": 0.935,
+              "status": "manual",
+              "start_s": 2.5,
+              "end_s": 5.5,
+              "duration_s": 3.0,
+              "confidence": null,
               "fallback_reason": null
             },
             "score": 95.11,
@@ -4011,11 +4011,11 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_target_centered",
-              "start_s": 0.0,
-              "end_s": 6.2,
-              "duration_s": 6.2,
-              "confidence": 0.996,
+              "status": "manual",
+              "start_s": 2.0,
+              "end_s": 5.0,
+              "duration_s": 3.0,
+              "confidence": null,
               "fallback_reason": null
             },
             "score": 92.87,
@@ -6944,11 +6944,11 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_target_centered",
-              "start_s": 0.0,
-              "end_s": 7.0,
-              "duration_s": 7.0,
-              "confidence": 0.97,
+              "status": "manual",
+              "start_s": 2.5,
+              "end_s": 6.0,
+              "duration_s": 3.5,
+              "confidence": null,
               "fallback_reason": null
             },
             "score": 96.09,
@@ -7032,12 +7032,12 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_extended_context",
-              "start_s": 0.0,
-              "end_s": 10.342,
-              "duration_s": 10.342,
-              "confidence": 0.957,
-              "fallback_reason": "target_region_requires_more_context"
+              "status": "manual",
+              "start_s": 4.0,
+              "end_s": 8.0,
+              "duration_s": 4.0,
+              "confidence": null,
+              "fallback_reason": null
             },
             "score": 95.91,
             "ranking_signals": {
@@ -9644,11 +9644,11 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_target_centered",
-              "start_s": 5.98,
-              "end_s": 12.98,
-              "duration_s": 7.0,
-              "confidence": 0.948,
+              "status": "manual",
+              "start_s": 3.0,
+              "end_s": 5.5,
+              "duration_s": 2.5,
+              "confidence": null,
               "fallback_reason": null
             },
             "score": 92.45,
@@ -9711,11 +9711,11 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_target_centered",
-              "start_s": 0.0,
-              "end_s": 5.29,
-              "duration_s": 5.29,
-              "confidence": 0.961,
+              "status": "manual",
+              "start_s": 1.2,
+              "end_s": 3.5,
+              "duration_s": 2.3,
+              "confidence": null,
               "fallback_reason": null
             },
             "score": 91.82,
@@ -14331,11 +14331,11 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_target_centered",
-              "start_s": 0.0,
-              "end_s": 6.137,
-              "duration_s": 6.137,
-              "confidence": 0.987,
+              "status": "manual",
+              "start_s": 3.6,
+              "end_s": 5.0,
+              "duration_s": 1.4,
+              "confidence": null,
               "fallback_reason": null
             },
             "score": 96.61,
@@ -16560,12 +16560,12 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_extended_context",
-              "start_s": 0.0,
-              "end_s": 12.0,
-              "duration_s": 12.0,
-              "confidence": 0.943,
-              "fallback_reason": "target_region_requires_more_context"
+              "status": "manual",
+              "start_s": 2.6,
+              "end_s": 7.0,
+              "duration_s": 4.4,
+              "confidence": null,
+              "fallback_reason": null
             },
             "score": 69.29,
             "ranking_signals": {
@@ -18995,11 +18995,11 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_target_centered",
-              "start_s": 0.0,
-              "end_s": 7.0,
-              "duration_s": 7.0,
-              "confidence": 0.999,
+              "status": "manual",
+              "start_s": 0.7,
+              "end_s": 2.7,
+              "duration_s": 2.0,
+              "confidence": null,
               "fallback_reason": null
             },
             "score": 94.96,
@@ -21957,12 +21957,12 @@
               "failure": null
             },
             "segment": {
-              "status": "ffmpeg_full_clip_fallback",
-              "start_s": 0.0,
-              "end_s": 12.0,
-              "duration_s": 12.0,
+              "status": "manual",
+              "start_s": 5.0,
+              "end_s": 7.3,
+              "duration_s": 2.3,
               "confidence": null,
-              "fallback_reason": "segment_selection_failed:'NoneType' object has no attribute 'get'"
+              "fallback_reason": null
             },
             "score": 19.0,
             "ranking_signals": {
@@ -24675,11 +24675,11 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_target_centered",
+              "status": "manual",
               "start_s": 0.0,
-              "end_s": 5.255,
-              "duration_s": 5.255,
-              "confidence": 0.214,
+              "end_s": 3.7,
+              "duration_s": 3.7,
+              "confidence": null,
               "fallback_reason": null
             },
             "score": 73.41,
@@ -25447,12 +25447,12 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_extended_context",
-              "start_s": 5.25,
-              "end_s": 17.25,
-              "duration_s": 12.0,
-              "confidence": 0.983,
-              "fallback_reason": "target_region_requires_more_context"
+              "status": "manual",
+              "start_s": 2.4,
+              "end_s": 8.0,
+              "duration_s": 5.6,
+              "confidence": null,
+              "fallback_reason": null
             },
             "score": 52.55,
             "ranking_signals": {
@@ -25816,12 +25816,12 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_extended_context",
-              "start_s": 0.0,
-              "end_s": 12.0,
-              "duration_s": 12.0,
-              "confidence": 0.961,
-              "fallback_reason": "target_region_requires_more_context"
+              "status": "manual",
+              "start_s": 1.5,
+              "end_s": 7.5,
+              "duration_s": 6.0,
+              "confidence": null,
+              "fallback_reason": null
             },
             "score": 95.83,
             "ranking_signals": {
@@ -26060,12 +26060,12 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_extended_context",
-              "start_s": 0.0,
-              "end_s": 11.059,
-              "duration_s": 11.059,
-              "confidence": 0.925,
-              "fallback_reason": "target_region_requires_more_context"
+              "status": "manual",
+              "start_s": 5.5,
+              "end_s": 9.1,
+              "duration_s": 3.6,
+              "confidence": null,
+              "fallback_reason": null
             },
             "score": 90.95,
             "ranking_signals": {
@@ -30117,11 +30117,11 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_target_centered",
-              "start_s": 0.0,
-              "end_s": 5.08,
-              "duration_s": 5.08,
-              "confidence": 0.992,
+              "status": "manual",
+              "start_s": 1.6,
+              "end_s": 3.6,
+              "duration_s": 2.0,
+              "confidence": null,
               "fallback_reason": null
             },
             "score": 87.82,
@@ -31704,12 +31704,12 @@
               "failure": null
             },
             "segment": {
-              "status": "ffmpeg_full_clip_fallback",
-              "start_s": 0.0,
-              "end_s": 12.0,
-              "duration_s": 12.0,
+              "status": "manual",
+              "start_s": 2.3,
+              "end_s": 6.3,
+              "duration_s": 4.0,
               "confidence": null,
-              "fallback_reason": "segment_selection_failed:'NoneType' object has no attribute 'get'"
+              "fallback_reason": null
             },
             "score": 47.2,
             "ranking_signals": {
@@ -32402,12 +32402,12 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_extended_context",
-              "start_s": 0.0,
-              "end_s": 10.5,
-              "duration_s": 10.5,
-              "confidence": 0.982,
-              "fallback_reason": "target_region_requires_more_context"
+              "status": "manual",
+              "start_s": 0.8,
+              "end_s": 6.0,
+              "duration_s": 5.2,
+              "confidence": null,
+              "fallback_reason": null
             },
             "score": 94.47,
             "ranking_signals": {
@@ -32606,11 +32606,11 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_target_centered",
-              "start_s": 23.5,
-              "end_s": 30.5,
-              "duration_s": 7.0,
-              "confidence": 0.993,
+              "status": "manual",
+              "start_s": 0.3,
+              "end_s": 5.4,
+              "duration_s": 5.1,
+              "confidence": null,
               "fallback_reason": null
             },
             "score": 92.98,
@@ -36461,11 +36461,11 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_target_centered",
-              "start_s": 0.0,
-              "end_s": 5.689,
-              "duration_s": 5.689,
-              "confidence": 0.958,
+              "status": "manual",
+              "start_s": 1.8,
+              "end_s": 3.8,
+              "duration_s": 2.0,
+              "confidence": null,
               "fallback_reason": null
             },
             "score": 92.79,
@@ -38248,11 +38248,11 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_target_centered",
-              "start_s": 11.5,
-              "end_s": 18.5,
-              "duration_s": 7.0,
-              "confidence": 0.975,
+              "status": "manual",
+              "start_s": 1.7,
+              "end_s": 5.5,
+              "duration_s": 3.8,
+              "confidence": null,
               "fallback_reason": null
             },
             "score": 84.24,
@@ -40399,12 +40399,12 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_extended_context",
-              "start_s": 2.25,
-              "end_s": 14.25,
-              "duration_s": 12.0,
-              "confidence": 1.0,
-              "fallback_reason": "target_region_requires_more_context"
+              "status": "manual",
+              "start_s": 0.4,
+              "end_s": 4.9,
+              "duration_s": 4.5,
+              "confidence": null,
+              "fallback_reason": null
             },
             "score": 84.05,
             "ranking_signals": {
@@ -41696,12 +41696,12 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_extended_context",
-              "start_s": 0.0,
-              "end_s": 12.0,
-              "duration_s": 12.0,
-              "confidence": 1.0,
-              "fallback_reason": "target_region_requires_more_context"
+              "status": "manual",
+              "start_s": 7.0,
+              "end_s": 11.7,
+              "duration_s": 4.7,
+              "confidence": null,
+              "fallback_reason": null
             },
             "score": 73.0,
             "ranking_signals": {
@@ -44776,12 +44776,12 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_extended_context",
-              "start_s": 0.0,
-              "end_s": 12.0,
-              "duration_s": 12.0,
-              "confidence": 1.0,
-              "fallback_reason": "target_region_requires_more_context"
+              "status": "manual",
+              "start_s": 1.7,
+              "end_s": 6.9,
+              "duration_s": 5.2,
+              "confidence": null,
+              "fallback_reason": null
             },
             "score": 94.04,
             "ranking_signals": {
@@ -44945,12 +44945,12 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_extended_context",
-              "start_s": 0.0,
-              "end_s": 11.879,
-              "duration_s": 11.879,
-              "confidence": 0.999,
-              "fallback_reason": "target_region_requires_more_context"
+              "status": "manual",
+              "start_s": 2.8,
+              "end_s": 5.5,
+              "duration_s": 2.7,
+              "confidence": null,
+              "fallback_reason": null
             },
             "score": 93.97,
             "ranking_signals": {
@@ -49348,11 +49348,11 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_target_centered",
-              "start_s": 0.0,
-              "end_s": 7.0,
-              "duration_s": 7.0,
-              "confidence": 0.972,
+              "status": "manual",
+              "start_s": 0.2,
+              "end_s": 2.2,
+              "duration_s": 2.0,
+              "confidence": null,
               "fallback_reason": null
             },
             "score": 85.22,
@@ -49882,12 +49882,12 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_extended_context",
-              "start_s": 0.0,
-              "end_s": 12.0,
-              "duration_s": 12.0,
-              "confidence": 0.999,
-              "fallback_reason": "target_region_requires_more_context"
+              "status": "manual",
+              "start_s": 2.0,
+              "end_s": 4.4,
+              "duration_s": 2.4,
+              "confidence": null,
+              "fallback_reason": null
             },
             "score": 75.38,
             "ranking_signals": {
@@ -53637,11 +53637,11 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_target_centered",
+              "status": "manual",
               "start_s": 0.0,
-              "end_s": 7.0,
-              "duration_s": 7.0,
-              "confidence": 0.986,
+              "end_s": 3.6,
+              "duration_s": 3.6,
+              "confidence": null,
               "fallback_reason": null
             },
             "score": 65.79,
@@ -54811,12 +54811,12 @@
               "failure": null
             },
             "segment": {
-              "status": "birdnet_extended_context",
-              "start_s": 56.25,
-              "end_s": 66.75,
-              "duration_s": 10.5,
-              "confidence": 0.918,
-              "fallback_reason": "target_region_requires_more_context"
+              "status": "manual",
+              "start_s": 1.5,
+              "end_s": 3.8,
+              "duration_s": 2.3,
+              "confidence": null,
+              "fallback_reason": null
             },
             "score": 31.73,
             "ranking_signals": {


### PR DESCRIPTION
## Summary
- add admin trim persistence/reset endpoints plus selected-clip trim controls and preview playback
- add export_app_audio.py to generate trimmed app audio from existing local app audio and write trim-aware manifests
- document the workflow and mark the implementation issues complete

## Tests
- uv run pytest test_admin_server.py test_export_app_audio.py test_populate_content.py test_smart_trim.py
- node --test admin/review-state.test.mjs admin/clip-evidence.test.mjs admin/trim-state.test.mjs
- uv run python3 export_app_audio.py --help